### PR TITLE
Remove importing annotations

### DIFF
--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 __copyright__ = "Copyright (C) 2013 Andreas Kloeckner"
 
 __license__ = """

--- a/pytential/qbx/refinement.py
+++ b/pytential/qbx/refinement.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import annotations
-
 __copyright__ = """
 Copyright (C) 2013 Andreas Kloeckner
 Copyright (C) 2016, 2017 Matt Wala

--- a/pytential/qbx/utils.py
+++ b/pytential/qbx/utils.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import annotations
-
 __copyright__ = """
 Copyright (C) 2016 Matt Wala
 """


### PR DESCRIPTION
Makes pytential compatible with python 3.6

Fixes https://github.com/inducer/pytential/issues/27