### PR TITLE
Tensor Product Element Support

### DIFF
--- a/pytential/qbx/refinement.py
+++ b/pytential/qbx/refinement.py
@@ -536,16 +536,10 @@ def _visualize_refinement(actx: PyOpenCLArrayContext, discr,
 
 
 def _make_quad_stage2_discr(lpot_source, stage2_density_discr):
-    from meshmode.discretization.poly_element import (
-            OrderAndTypeBasedGroupFactory,
-            QuadratureSimplexElementGroup,
-            GaussLegendreTensorProductElementGroup)
+    from meshmode.discretization.poly_element import QuadratureGroupFactory
 
     return stage2_density_discr.copy(
-            group_factory=OrderAndTypeBasedGroupFactory(
-                lpot_source.fine_order,
-                simplex_group_class=QuadratureSimplexElementGroup,
-                tensor_product_group_class=GaussLegendreTensorProductElementGroup),
+            group_factory=QuadratureGroupFactory(lpot_source.fine_order),
             )
 
 
@@ -833,12 +827,6 @@ def _refine_for_global_qbx(places, dofdesc, wrangler,
 
     if force_stage2_uniform_refinement_rounds is None:
         force_stage2_uniform_refinement_rounds = 0
-
-    if group_factory is None:
-        from meshmode.discretization.poly_element import \
-                InterpolatoryQuadratureSimplexGroupFactory
-        group_factory = InterpolatoryQuadratureSimplexGroupFactory(
-                lpot_source.density_discr.groups[0].order)
 
     # }}}
 

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -309,6 +309,9 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
 
     # }}}
 
+    def map_error_expression(self, expr):
+        raise RuntimeError(expr.message)
+
     def map_is_shape_class(self, expr):
         discr = self.places.get_discretization(
             expr.dofdesc.geometry, expr.dofdesc.discr_stage)

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -78,6 +78,7 @@ class IdentityMapper(IdentityMapperBase):
     map_node_coordinate_component = map_ones
     map_parametrization_gradient = map_ones
     map_parametrization_derivative = map_ones
+    map_is_shape_class = map_ones
 
     # }}}
 
@@ -128,6 +129,9 @@ class CombineMapper(CombineMapperBase):
                 (self.rec(name_expr)
                 for name_expr in expr.extra_vars.values())
                 ])
+
+    def map_is_shape_class(self, expr):
+        return set()
 
 
 class Collector(CollectorBase, CombineMapper):
@@ -291,6 +295,9 @@ class LocationTagger(CSECachingMapperMixin, IdentityMapper):
             to_dd = to_dd.copy(geometry=self.default_source)
 
         return type(expr)(from_dd, to_dd, self.operand_rec(expr.operand))
+
+    def map_is_shape_class(self, expr):
+        return type(expr)(expr.shape, self._default_dofdesc(expr.dofdesc))
 
     def operand_rec(self, expr):
         return self.rec(expr)
@@ -690,6 +697,10 @@ class StringifyMapper(BaseStringifyMapper):
                 stringify_where(expr.from_dd),
                 stringify_where(expr.to_dd),
                 self.rec(expr.operand, PREC_PRODUCT))
+
+    def map_is_shape_class(self, expr, enclosing_prec):
+        return "IsShape[{}]({})".format(stringify_where(expr.dofdesc),
+                                        expr.shape.__name__)
 
 # }}}
 

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -79,6 +79,7 @@ class IdentityMapper(IdentityMapperBase):
     map_parametrization_gradient = map_ones
     map_parametrization_derivative = map_ones
     map_is_shape_class = map_ones
+    map_error_expression = map_ones
 
     # }}}
 
@@ -132,6 +133,8 @@ class CombineMapper(CombineMapperBase):
 
     def map_is_shape_class(self, expr):
         return set()
+
+    map_error_expression = map_is_shape_class
 
 
 class Collector(CollectorBase, CombineMapper):
@@ -298,6 +301,9 @@ class LocationTagger(CSECachingMapperMixin, IdentityMapper):
 
     def map_is_shape_class(self, expr):
         return type(expr)(expr.shape, self._default_dofdesc(expr.dofdesc))
+
+    def map_error_expression(self, expr):
+        return expr
 
     def operand_rec(self, expr):
         return self.rec(expr)

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -94,6 +94,11 @@ DOF Description
 .. autoclass:: DOFDescriptor
 .. autofunction:: as_dofdesc
 
+Diagnostics
+^^^^^^^^^^^
+
+.. autoclass:: ErrorExpression
+
 .. _placeholders:
 
 Placeholders
@@ -438,6 +443,23 @@ class Expression(ExpressionBase):
     def make_stringifier(self, originating_stringifier=None):
         from pytential.symbolic.mappers import StringifyMapper
         return StringifyMapper()
+
+
+class ErrorExpression(Expression):
+    """An expression that, if evaluated, causes an error with the supplied
+    *message*.
+
+    .. automethod:: __init__
+    """
+    init_arg_names = ("message",)
+
+    def __init__(self, message):
+        self.message = message
+
+    def __getinitargs__(self):
+        return (self.message,)
+
+    mapper_method = intern("map_error_expression")
 
 
 def make_sym_mv(name, num_components):
@@ -1013,7 +1035,8 @@ def _mapping_max_stretch_factor(ambient_dim, dim=None, dofdesc=None,
     stretch_factor = If(IsShapeClass(mp.Simplex, dofdesc),
                         simplex_stretch_factor,
                         If(IsShapeClass(mp.Hypercube, dofdesc),
-                           hypercube_stretch_factor, 0)
+                           hypercube_stretch_factor,
+                           ErrorExpression("unknown reference element shape"))
                         )
 
     return cse(stretch_factor, "mapping_stretch_factor", cse_scope.DISCRETIZATION)

--- a/test/test_global_qbx.py
+++ b/test/test_global_qbx.py
@@ -40,6 +40,8 @@ from arraycontext import pytest_generate_tests_for_array_contexts
 from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 
 from extra_curve_data import horseshoe
+from extra_int_eq_data import QuadSpheroidTestCase
+
 import logging
 logger = logging.getLogger(__name__)
 
@@ -76,25 +78,45 @@ def iter_elements(discr):
 
 
 def run_source_refinement_test(actx_factory, mesh, order,
-        helmholtz_k=None, visualize=False):
+        helmholtz_k=None, surface_name="surface", visualize=False):
     actx = actx_factory()
 
     # {{{ initial geometry
 
     from meshmode.discretization import Discretization
-    from meshmode.discretization.poly_element import (
-            InterpolatoryQuadratureSimplexGroupFactory)
-    discr = Discretization(actx, mesh,
-            InterpolatoryQuadratureSimplexGroupFactory(order))
+    from meshmode.discretization.poly_element import \
+            InterpolatoryQuadratureGroupFactory
+    discr = Discretization(actx, mesh, InterpolatoryQuadratureGroupFactory(order))
 
     lpot_source = QBXLayerPotentialSource(discr,
             qbx_order=order,  # not used in refinement
             fine_order=order)
     places = GeometryCollection(lpot_source)
 
+    logger.info("nelements: %d", discr.mesh.nelements)
+    logger.info("ndofs: %d", discr.ndofs)
+
     # }}}
 
     # {{{ refined geometry
+
+    def _visualize_quad_resolution(_places, dd, suffix):
+        if dd.discr_stage is None:
+            vis_discr = lpot_source.density_discr
+        else:
+            vis_discr = _places.get_discretization(dd.geometry, dd.discr_stage)
+
+        stretch = bind(_places,
+                sym._simplex_mapping_max_stretch_factor(
+                    _places.ambient_dim, with_elementwise_max=False),
+                auto_where=dd)(actx)
+
+        from meshmode.discretization.visualization import make_visualizer
+        vis = make_visualizer(actx, vis_discr, order, force_equidistant=True)
+        vis.write_vtk_file(
+                f"global-qbx-source-refinement-{surface_name}-{order}-{suffix}.vtu",
+                [("stretch", stretch)],
+                overwrite=True, use_high_order=True)
 
     kernel_length_scale = 5 / helmholtz_k if helmholtz_k else None
     expansion_disturbance_tolerance = 0.025
@@ -103,7 +125,13 @@ def run_source_refinement_test(actx_factory, mesh, order,
     places = refine_geometry_collection(places,
             kernel_length_scale=kernel_length_scale,
             expansion_disturbance_tolerance=expansion_disturbance_tolerance,
-            visualize=visualize)
+            visualize=False)
+
+    if visualize:
+        dd = places.auto_source
+        _visualize_quad_resolution(places, dd.copy(discr_stage=None), "original")
+        _visualize_quad_resolution(places, dd.to_stage1(), "stage1")
+        _visualize_quad_resolution(places, dd.to_stage2(), "stage2")
 
     # }}}
 
@@ -216,21 +244,29 @@ def run_source_refinement_test(actx_factory, mesh, order,
     ("20-to-1 ellipse", partial(mgen.ellipse, 20), 100),
     ("horseshoe", horseshoe, 64),
     ])
-def test_source_refinement_2d(actx_factory, curve_name, curve_f, nelements):
+def test_source_refinement_2d(actx_factory,
+        curve_name, curve_f, nelements, visualize=False):
     helmholtz_k = 10
     order = 8
 
     mesh = mgen.make_curve_mesh(curve_f, np.linspace(0, 1, nelements+1), order)
-    run_source_refinement_test(actx_factory, mesh, order, helmholtz_k)
+    run_source_refinement_test(actx_factory, mesh, order,
+            helmholtz_k=helmholtz_k,
+            surface_name=curve_name,
+            visualize=visualize)
 
 
 @pytest.mark.parametrize(("surface_name", "surface_f", "order"), [
     ("sphere", partial(mgen.generate_sphere, 1), 4),
     ("torus", partial(mgen.generate_torus, 3, 1, n_minor=10, n_major=7), 6),
+    ("spheroid-quad", lambda order: QuadSpheroidTestCase().get_mesh(2, order), 4),
     ])
-def test_source_refinement_3d(actx_factory, surface_name, surface_f, order):
+def test_source_refinement_3d(actx_factory,
+        surface_name, surface_f, order, visualize=False):
     mesh = surface_f(order=order)
-    run_source_refinement_test(actx_factory, mesh, order)
+    run_source_refinement_test(actx_factory, mesh, order,
+            surface_name=surface_name,
+            visualize=visualize)
 
 
 @pytest.mark.parametrize(("curve_name", "curve_f", "nelements"), [

--- a/test/test_layer_pot_identity.py
+++ b/test/test_layer_pot_identity.py
@@ -28,7 +28,6 @@ import numpy.linalg as la
 from arraycontext import flatten, unflatten
 from pytential import bind, sym, norm
 from pytential import GeometryCollection
-import meshmode.mesh.generation as mgen
 from sumpy.kernel import LaplaceKernel, HelmholtzKernel
 # from sumpy.visualization import FieldPlotter
 
@@ -36,6 +35,7 @@ from meshmode import _acf           # noqa: F401
 from arraycontext import pytest_generate_tests_for_array_contexts
 from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 
+import extra_int_eq_data as ied
 import logging
 logger = logging.getLogger(__name__)
 
@@ -53,62 +53,21 @@ d1 = sym.Derivative()
 d2 = sym.Derivative()
 
 
-def get_sphere_mesh(refinement_increment, target_order):
-    from meshmode.mesh.generation import generate_sphere
-    return generate_sphere(1, target_order,
-            uniform_refinement_rounds=refinement_increment)
-
-
-class StarfishGeometry:
-    def __init__(self, n_arms=5, amplitude=0.25):
-        self.n_arms = n_arms
-        self.amplitude = amplitude
-
-    @property
-    def mesh_name(self):
-        return "%d-starfish-%s" % (
-                self.n_arms,
-                self.amplitude)
-
-    dim = 2
-
-    resolutions = [30, 50, 70, 90]
-
-    def get_mesh(self, nelements, target_order):
-        return mgen.make_curve_mesh(
-                mgen.NArmedStarfish(self.n_arms, self.amplitude),
-                np.linspace(0, 1, nelements+1),
-                target_order)
-
-
-class WobblyCircleGeometry:
-    dim = 2
-    mesh_name = "wobbly-circle"
-
-    resolutions = [2000, 3000, 4000]
-
-    def get_mesh(self, resolution, target_order):
-        return mgen.make_curve_mesh(
-                mgen.WobblyCircle.random(30, seed=30),
-                np.linspace(0, 1, resolution+1),
-                target_order)
-
-
-class SphereGeometry:
-    mesh_name = "sphere"
-    dim = 3
-
+class SphereTestCase(ied.SphereTestCase):
     resolutions = [0, 1]
 
-    def get_mesh(self, resolution, tgt_order):
-        return get_sphere_mesh(resolution, tgt_order)
+
+class QuadSphereTestCase(ied.QuadSpheroidTestCase):
+    name = "sphere-quad"
+    aspect_ratio = 1
+    resolutions = [0, 1]
 
 
 class GreenExpr:
     zero_op_name = "green"
+    order_drop = 0
 
     def get_zero_op(self, kernel, **knl_kwargs):
-
         u_sym = sym.var("u")
         dn_u_sym = sym.var("dn_u")
 
@@ -117,11 +76,10 @@ class GreenExpr:
             - sym.D(kernel, u_sym, qbx_forced_limit="avg", **knl_kwargs)
             - 0.5*u_sym)
 
-    order_drop = 0
-
 
 class GradGreenExpr:
     zero_op_name = "grad_green"
+    order_drop = 1
 
     def get_zero_op(self, kernel, **knl_kwargs):
         d = kernel.dim
@@ -137,11 +95,10 @@ class GradGreenExpr:
                 - 0.5*grad_u_sym
                 ).as_vector()
 
-    order_drop = 1
-
 
 class ZeroCalderonExpr:
     zero_op_name = "calderon"
+    order_drop = 1
 
     def get_zero_op(self, kernel, **knl_kwargs):
         assert isinstance(kernel, LaplaceKernel)
@@ -155,11 +112,9 @@ class ZeroCalderonExpr:
         Sp = partial(sym.Sp, qbx_forced_limit="avg")
 
         return (
-                    -Dp(kernel, S(kernel, u_sym))
-                    - 0.25*u_sym + Sp(kernel, Sp(kernel, u_sym))
-                    )
-
-    order_drop = 1
+                -Dp(kernel, S(kernel, u_sym))
+                - 0.25*u_sym + Sp(kernel, Sp(kernel, u_sym))
+                )
 
 
 class StaticTestCase:
@@ -169,7 +124,7 @@ class StaticTestCase:
 
 class StarfishGreenTest(StaticTestCase):
     expr = GreenExpr()
-    geometry = StarfishGeometry()
+    geometry = ied.StarfishTestCase()
     k = 0
     qbx_order = 5
     fmm_order = 15
@@ -183,7 +138,7 @@ class StarfishGreenTest(StaticTestCase):
 
 class WobblyCircleGreenTest(StaticTestCase):
     expr = GreenExpr()
-    geometry = WobblyCircleGeometry()
+    geometry = ied.WobbleCircleTestCase()
     k = 0
     qbx_order = 3
     fmm_order = 10
@@ -195,7 +150,7 @@ class WobblyCircleGreenTest(StaticTestCase):
 
 class SphereGreenTest(StaticTestCase):
     expr = GreenExpr()
-    geometry = SphereGeometry()
+    geometry = SphereTestCase()
     k = 0
     qbx_order = 3
     fmm_order = 10
@@ -214,27 +169,33 @@ class DynamicTestCase:
         self.geometry = geometry
         self.expr = expr
         self.k = k
-        self.qbx_order = 5 if geometry.dim == 2 else 3
+        self.qbx_order = 5 if geometry.ambient_dim == 2 else 3
         self.fmm_backend = fmm_backend
 
-        if geometry.dim == 2:
+        if geometry.ambient_dim == 2:
             order_bump = 15
-        elif geometry.dim == 3:
+        elif geometry.ambient_dim == 3:
             order_bump = 8
+        else:
+            raise ValueError(f"unsupported dimension: {geometry.ambient_dim}")
 
         if fmm_order is None:
             self.fmm_order = self.qbx_order + order_bump
         else:
             self.fmm_order = fmm_order
 
+    @property
+    def resolutions(self):
+        return self.geometry.resolutions
+
     def check(self):
         from warnings import warn
-        if (self.geometry.mesh_name == "sphere"
+        if (self.geometry.name == "sphere"
                 and self.k != 0
                 and self.fmm_backend == "sumpy"):
             warn("both direct eval and generating the FMM kernels are too slow")
 
-        if (self.geometry.mesh_name == "sphere"
+        if (self.geometry.name == "sphere"
                 and self.expr.zero_op_name == "grad_green"):
             warn("does not achieve sufficient precision")
 
@@ -244,7 +205,7 @@ class DynamicTestCase:
 
 @pytest.mark.slowtest
 @pytest.mark.parametrize("case", [
-        DynamicTestCase(SphereGeometry(), GreenExpr(), 0),
+        DynamicTestCase(SphereTestCase(), GreenExpr(), 0),
 ])
 def test_identity_convergence_slow(actx_factory, case):
     test_identity_convergence(actx_factory, case)
@@ -252,18 +213,22 @@ def test_identity_convergence_slow(actx_factory, case):
 
 @pytest.mark.parametrize("case", [
         # 2d
-        DynamicTestCase(StarfishGeometry(), GreenExpr(), 0),
-        DynamicTestCase(StarfishGeometry(), GreenExpr(), 1.2),
-        DynamicTestCase(StarfishGeometry(), GradGreenExpr(), 0),
-        DynamicTestCase(StarfishGeometry(), GradGreenExpr(), 1.2),
-        DynamicTestCase(StarfishGeometry(), ZeroCalderonExpr(), 0),
+        DynamicTestCase(ied.StarfishTestCase(), GreenExpr(), 0),
+        DynamicTestCase(ied.StarfishTestCase(), GreenExpr(), 1.2),
+        DynamicTestCase(ied.StarfishTestCase(), GradGreenExpr(), 0),
+        DynamicTestCase(ied.StarfishTestCase(), GradGreenExpr(), 1.2),
+        DynamicTestCase(ied.StarfishTestCase(), ZeroCalderonExpr(), 0),
         # test target derivatives with direct evaluation
-        DynamicTestCase(StarfishGeometry(), ZeroCalderonExpr(), 0, fmm_order=False),
-        DynamicTestCase(StarfishGeometry(), GreenExpr(), 0, fmm_backend="fmmlib"),
-        DynamicTestCase(StarfishGeometry(), GreenExpr(), 1.2, fmm_backend="fmmlib"),
+        DynamicTestCase(
+            ied.StarfishTestCase(), ZeroCalderonExpr(), 0, fmm_order=False),
+        DynamicTestCase(
+            ied.StarfishTestCase(), GreenExpr(), 0, fmm_backend="fmmlib"),
+        DynamicTestCase(
+            ied.StarfishTestCase(), GreenExpr(), 1.2, fmm_backend="fmmlib"),
         # 3d
-        DynamicTestCase(SphereGeometry(), GreenExpr(), 0, fmm_backend="fmmlib"),
-        DynamicTestCase(SphereGeometry(), GreenExpr(), 1.2, fmm_backend="fmmlib")
+        DynamicTestCase(SphereTestCase(), GreenExpr(), 0, fmm_backend="fmmlib"),
+        DynamicTestCase(SphereTestCase(), GreenExpr(), 1.2, fmm_backend="fmmlib"),
+        DynamicTestCase(QuadSphereTestCase(), GreenExpr(), 0, fmm_backend="fmmlib"),
 ])
 def test_identity_convergence(actx_factory,  case, visualize=False):
     logging.basicConfig(level=logging.INFO)
@@ -281,10 +246,7 @@ def test_identity_convergence(actx_factory,  case, visualize=False):
     from pytools.convergence import EOCRecorder
     eoc_rec = EOCRecorder()
 
-    for resolution in (
-            getattr(case, "resolutions", None)
-            or case.geometry.resolutions
-            ):
+    for resolution in case.resolutions:
         mesh = case.geometry.get_mesh(resolution, target_order)
         if mesh is None:
             break
@@ -302,12 +264,11 @@ def test_identity_convergence(actx_factory,  case, visualize=False):
 
         from meshmode.discretization import Discretization
         from meshmode.discretization.poly_element import \
-                InterpolatoryQuadratureSimplexGroupFactory
-        from pytential.qbx import QBXLayerPotentialSource
+                InterpolatoryQuadratureGroupFactory
         pre_density_discr = Discretization(
-                actx, mesh,
-                InterpolatoryQuadratureSimplexGroupFactory(target_order))
+                actx, mesh, InterpolatoryQuadratureGroupFactory(target_order))
 
+        from pytential.qbx import QBXLayerPotentialSource
         qbx = QBXLayerPotentialSource(
                 pre_density_discr, 4*target_order,
                 case.qbx_order,
@@ -377,7 +338,7 @@ def test_identity_convergence(actx_factory,  case, visualize=False):
         grad_u_dev = unflatten(
                 normal, actx.from_numpy(grad_u.ravel()), actx, strict=False)
 
-        key = (case.qbx_order, case.geometry.mesh_name, resolution,
+        key = (case.qbx_order, case.geometry.name, resolution,
                 case.expr.zero_op_name)
 
         bound_op = bind(places, case.expr.get_zero_op(k_sym, **knl_kwargs))

--- a/test/test_stokes.py
+++ b/test/test_stokes.py
@@ -342,8 +342,8 @@ def run_stokes_identity(actx_factory, case, identity, resolution, visualize=Fals
     # }}}
 
     if visualize:
-        filename = "stokes_{}_{}d_resolution_{}".format(
-                type(identity).__name__.lower(), places.ambient_dim, resolution)
+        filename = "stokes_{}_{}_resolution_{}".format(
+                type(identity).__name__.lower(), case.name, resolution)
 
         if places.ambient_dim == 2:
             result = actx.to_numpy(flatten(result, actx))


### PR DESCRIPTION
Mostly just tried to see what happens, in particular with the quad refinement. 

Currently it does seem to [refine something](https://i.imgur.com/srfYhUf.jpg), but looks a bit weird. Haven't looked into it, but `_simplex_mapping_max_stretch_factor` is suspiciously named when used with squares.

- [x] Requires inducer/meshmode#261
- [x] Point `requirements.txt` back to `meshmode@main`