### PR TITLE
Add missing source/target kernels to P2PMatrixBuilder

### DIFF
--- a/pytential/symbolic/matrix.py
+++ b/pytential/symbolic/matrix.py
@@ -453,7 +453,9 @@ class P2PMatrixBuilder(MatrixBuilderBase):
                         )
 
             from sumpy.p2p import P2PMatrixGenerator
-            mat_gen = P2PMatrixGenerator(actx.context, (kernel,),
+            mat_gen = P2PMatrixGenerator(actx.context,
+                    source_kernels=(kernel,),
+                    target_kernels=(expr.target_kernel,),
                     exclude_self=self.exclude_self)
 
             from meshmode.dof_array import flatten, thaw


### PR DESCRIPTION
I missed this while looking over #38, but it seems like it should be there, right?