### PR TITLE
Faster direct evaluation

### DIFF
--- a/examples/fmm-error.py
+++ b/examples/fmm-error.py
@@ -55,7 +55,7 @@ def main():
     places = GeometryCollection({
         "unaccel_qbx": unaccel_qbx,
         "qbx": unaccel_qbx.copy(fmm_order=10),
-        "targets": PointsTarget(fplot.points)
+        "targets": PointsTarget(actx.freeze(actx.from_numpy(fplot.points)))
         })
     density_discr = places.get_discretization("unaccel_qbx")
 

--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -860,7 +860,7 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
 
         # {{{ off-surface interactions
 
-        if len(other_outputs) > 0:
+        if other_outputs:
             p2p = self.get_p2p(actx, insn.target_kernels, insn.source_kernels)
             lpot_applier_on_tgt_subset = self.get_lpot_applier_on_tgt_subset(
                     insn.target_kernels, insn.source_kernels)

--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -860,9 +860,9 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
                     target_name)(actx)
 
             evt, output_for_each_kernel = p2p(queue,
-                    targts=flat_target_nodes,
+                    targets=flat_target_nodes,
                     sources=flat_source_nodes,
-                    strengths=flat_strengths,
+                    strength=flat_strengths,
                     **kernel_args)
 
             target_discrs_and_qbx_sides = ((target_discr, qbx_forced_limit),)

--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -802,6 +802,8 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
         other_outputs = defaultdict(list)
 
         for i, o in enumerate(insn.outputs):
+            # For purposes of figuring out whether this is a self-interaction,
+            # disregard discr_stage.
             source_dd = insn.source.copy(discr_stage=o.target_name.discr_stage)
 
             target_discr = bound_expr.places.get_discretization(
@@ -868,6 +870,7 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
                     target_name.geometry, target_name.discr_stage)
             flat_target_nodes = _flat_nodes(target_name)
 
+            # FIXME: (Somewhat wastefully) compute P2P for all targets
             evt, output_for_each_kernel = p2p(queue,
                     targets=flat_target_nodes,
                     sources=flat_source_nodes,

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -303,6 +303,11 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
         arg, = args
         return abs(self.rec(arg))
 
+    def apply_flatten(self, args):
+        from pytential.utils import flatten_if_needed
+        arg, = args
+        return flatten_if_needed(self.array_context, self.rec(arg))
+
     # }}}
 
     def map_call(self, expr):
@@ -310,7 +315,7 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
                 EvalMapperFunction, NumpyMathFunction)
 
         if isinstance(expr.function, EvalMapperFunction):
-            return getattr(self, "apply_"+expr.function.name)(expr.parameters)
+            return getattr(self, f"apply_{expr.function.name}")(expr.parameters)
         elif isinstance(expr.function, NumpyMathFunction):
             args = [self.rec(arg) for arg in expr.parameters]
             from numbers import Number

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -210,7 +210,7 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
         if isinstance(x, DOFArray):
             return thaw(self.array_context, x)
         else:
-            return self.array_context.thaw(x)
+            return self.array_context.thaw(x).copy()
 
     def map_num_reference_derivative(self, expr):
         discr = self.places.get_discretization(

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -54,13 +54,13 @@ __doc__ = """
 
 class EvaluationMapperCSECacheKey:
     """Serves as a unique key for the common subexpression cache in
-    :func:`GeometryCollection._get_cache`.
+    :meth:`GeometryCollection._get_cache`.
     """
 
 
 class EvaluationMapperBoundOpCacheKey:
     """Serves as a unique key for the bound operator cache in
-    :func:`GeometryCollection._get_cache`.
+    :meth:`GeometryCollection._get_cache`.
     """
 
 
@@ -630,13 +630,13 @@ def _is_valid_identifier(name):
 
 class _GeometryCollectionDiscretizationCacheKey:
     """Serves as a unique key for the discretization cache in
-    :func:`GeometryCollection._get_cache`.
+    :meth:`GeometryCollection._get_cache`.
     """
 
 
 class _GeometryCollectionConnectionCacheKey:
     """Serves as a unique key for the connection cache in
-    :func:`GeometryCollection._get_cache`.
+    :meth:`GeometryCollection._get_cache`.
     """
 
 

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -257,10 +257,6 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
         else:
             raise TypeError("cannot interpolate `{}`".format(type(operand)))
 
-    def map_flatten(self, expr):
-        from pytential.utils import flatten_if_needed
-        return flatten_if_needed(self.array_context, self.rec(expr.operand))
-
     def map_common_subexpression(self, expr):
         if expr.scope == sym.cse_scope.EXPRESSION:
             cache = self.bound_expr._get_cache("cse")

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -210,7 +210,7 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
         if isinstance(x, DOFArray):
             return thaw(self.array_context, x)
         else:
-            return self.array_context.thaw(x).copy()
+            return self.array_context.thaw(x)
 
     def map_num_reference_derivative(self, expr):
         discr = self.places.get_discretization(

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -1095,22 +1095,6 @@ def bind(places, expr, auto_where=None):
 
     return BoundExpression(places, expr)
 
-
-def _bind_tagged_expr(places, expr, dofdesc):
-    """This is meant to bind simple expressions (that do not contain
-    :class:`~pytential.symbolic.primitives.IntG`) that have already been
-    tagged.
-    """
-    if dofdesc is None:
-        dofdesc = places.auto_source
-    dofdesc = sym.as_dofdesc(dofdesc)
-
-    if dofdesc.discr_stage is sym.QBX_SOURCE_QUAD_STAGE2:
-        from pytential.symbolic.mappers import InterpolationPreprocessor
-        expr = InterpolationPreprocessor(places)(expr)
-
-    return BoundExpression(places, expr)
-
 # }}}
 
 

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -257,6 +257,10 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
         else:
             raise TypeError("cannot interpolate `{}`".format(type(operand)))
 
+    def map_flatten(self, expr):
+        from pytential.utils import flatten_if_needed
+        return flatten_if_needed(self.array_context, self.rec(expr.operand))
+
     def map_common_subexpression(self, expr):
         if expr.scope == sym.cse_scope.EXPRESSION:
             cache = self.bound_expr._get_cache("cse")
@@ -302,11 +306,6 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
     def apply_abs(self, args):
         arg, = args
         return abs(self.rec(arg))
-
-    def apply_flatten(self, args):
-        from pytential.utils import flatten_if_needed
-        arg, = args
-        return flatten_if_needed(self.array_context, self.rec(arg))
 
     # }}}
 

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -1088,6 +1088,22 @@ def bind(places, expr, auto_where=None):
 
     return BoundExpression(places, expr)
 
+
+def _bind_tagged_expr(places, expr, dofdesc):
+    """This is meant to bind simple expressions (that do not contain
+    :class:`~pytential.symbolic.primitives.IntG`) that have already been
+    tagged.
+    """
+    if dofdesc is None:
+        dofdesc = places.auto_source
+    dofdesc = sym.as_dofdesc(dofdesc)
+
+    if dofdesc.discr_stage is sym.QBX_SOURCE_QUAD_STAGE2:
+        from pytential.symbolic.mappers import InterpolationPreprocessor
+        expr = InterpolationPreprocessor(places)(expr)
+
+    return BoundExpression(places, expr)
+
 # }}}
 
 

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -115,6 +115,7 @@ class CombineMapper(CombineMapperBase):
     map_elementwise_min = map_node_sum
     map_elementwise_max = map_node_sum
     map_interpolation = map_node_sum
+    map_flatten = map_node_sum
 
     def map_int_g(self, expr):
         return self.combine(

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -64,7 +64,6 @@ class IdentityMapper(IdentityMapperBase):
 
     map_elementwise_min = map_elementwise_sum
     map_elementwise_max = map_elementwise_sum
-    map_flatten = map_elementwise_sum
 
     def map_num_reference_derivative(self, expr):
         return type(expr)(expr.ref_axes, self.rec(expr.operand),
@@ -116,7 +115,6 @@ class CombineMapper(CombineMapperBase):
     map_elementwise_min = map_node_sum
     map_elementwise_max = map_node_sum
     map_interpolation = map_node_sum
-    map_flatten = map_node_sum
 
     def map_int_g(self, expr):
         return self.combine(

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -64,6 +64,7 @@ class IdentityMapper(IdentityMapperBase):
 
     map_elementwise_min = map_elementwise_sum
     map_elementwise_max = map_elementwise_sum
+    map_flatten = map_elementwise_sum
 
     def map_num_reference_derivative(self, expr):
         return type(expr)(expr.ref_axes, self.rec(expr.operand),

--- a/pytential/symbolic/matrix.py
+++ b/pytential/symbolic/matrix.py
@@ -329,7 +329,7 @@ class MatrixBuilder(MatrixBuilderBase):
             operand = unflatten_from_numpy(actx, discr, operand)
             return flatten_to_numpy(actx, conn(operand))
         elif isinstance(operand, np.ndarray) and operand.ndim == 2:
-            cache = self.places._get_cache("direct_resampler")
+            cache = self.places._get_cache((MatrixBuilder, "direct_resampler"))
             key = (expr.from_dd.geometry,
                     expr.from_dd.discr_stage,
                     expr.to_dd.discr_stage)

--- a/pytential/symbolic/matrix.py
+++ b/pytential/symbolic/matrix.py
@@ -304,6 +304,12 @@ class MatrixBlockBuilderBase(MatrixBuilderBase):
 # FIXME: PyOpenCL doesn't do all the required matrix math yet.
 # We'll cheat and build the matrix on the host.
 
+class MatrixBuilderDirectResamplerCacheKey:
+    """Serves as a unique key for the resampler cache in
+    :meth:`pytential.symbolic.execution.GeometryCollection._get_cache`.
+    """
+
+
 class MatrixBuilder(MatrixBuilderBase):
     def __init__(self, actx, dep_expr, other_dep_exprs,
             dep_source, dep_discr, places, context):
@@ -329,7 +335,7 @@ class MatrixBuilder(MatrixBuilderBase):
             operand = unflatten_from_numpy(actx, discr, operand)
             return flatten_to_numpy(actx, conn(operand))
         elif isinstance(operand, np.ndarray) and operand.ndim == 2:
-            cache = self.places._get_cache((MatrixBuilder, "direct_resampler"))
+            cache = self.places._get_cache(MatrixBuilderDirectResamplerCacheKey)
             key = (expr.from_dd.geometry,
                     expr.from_dd.discr_stage,
                     expr.to_dd.discr_stage)

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -509,6 +509,7 @@ real = EvalMapperFunction("real")
 imag = EvalMapperFunction("imag")
 conj = EvalMapperFunction("conj")
 abs = EvalMapperFunction("abs")
+flatten = EvalMapperFunction("flatten")
 
 sqrt = NumpyMathFunction("sqrt")
 
@@ -1119,6 +1120,28 @@ def weights_and_area_elements(ambient_dim, dim=None, dofdesc=None):
     return cse(area * QWeight(dofdesc=dofdesc),
             "weights_area_elements",
             cse_scope.DISCRETIZATION)
+
+# }}}
+
+
+# {{{ flattened quantities
+
+def _flat_nodes(ambient_dim, dofdesc=None):
+    return cse(
+            flatten(nodes(ambient_dim, dofdesc=dofdesc).as_vector()),
+            scope=cse_scope.DISCRETIZATION)
+
+
+def _flat_expansion_radii(ambient_dim, dim=None, dofdesc=None):
+    return cse(
+            flatten(expansion_radii(ambient_dim, dim=dim, dofdesc=dofdesc)),
+            scope=cse_scope.DISCRETIZATION)
+
+
+def _flat_expansion_centers(ambient_dim, side, dim=None, dofdesc=None):
+    return cse(
+            flatten(expansion_centers(ambient_dim, side, dim=dim, dofdesc=dofdesc)),
+            scope=cse_scope.DISCRETIZATION)
 
 # }}}
 

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -325,7 +325,8 @@ class DOFDescriptor:
         :class:`GRANULARITY_ELEMENT` (one DOF per element).
     """
 
-    def __init__(self, geometry=None, discr_stage=None, granularity=None):
+    def __init__(self, geometry=None,
+            discr_stage=None, granularity=None, _is_flattened=False):
         if granularity is None:
             granularity = GRANULARITY_NODE
 
@@ -344,7 +345,11 @@ class DOFDescriptor:
         self.discr_stage = discr_stage
         self.granularity = granularity
 
-    def copy(self, geometry=None, discr_stage=_NoArgSentinel, granularity=None):
+        self._is_flattened = _is_flattened
+
+    def copy(self, geometry=None,
+            discr_stage=_NoArgSentinel,
+            granularity=None, _is_flattened=None):
         if isinstance(geometry, DOFDescriptor):
             discr_stage = geometry.discr_stage \
                     if discr_stage is _NoArgSentinel else discr_stage
@@ -356,7 +361,9 @@ class DOFDescriptor:
                 granularity=(self.granularity
                     if granularity is None else granularity),
                 discr_stage=(self.discr_stage
-                    if discr_stage is _NoArgSentinel else discr_stage))
+                    if discr_stage is _NoArgSentinel else discr_stage),
+                _is_flattened=(self._is_flattened
+                    if _is_flattened is None else _is_flattened))
 
     def to_stage1(self):
         return self.copy(discr_stage=QBX_SOURCE_STAGE1)
@@ -571,19 +578,20 @@ class _Flatten(Expression):
     """Represents a flattened quantity, in the sense of
     :func:`meshmode.dof_array.flatten`.
     """
-    init_arg_names = ("operand",)
+    init_arg_names = ("operand", "dofdesc")
 
-    def __new__(cls, operand):
+    def __new__(cls, operand, dofdesc):
         if isinstance(operand, np.ndarray):
-            return componentwise(lambda op: cls(op), operand)
+            return componentwise(lambda op: cls(op, dofdesc), operand)
         else:
             return Expression.__new__(cls)
 
-    def __init__(self, operand):
+    def __init__(self, operand, dofdesc):
         self.operand = operand
+        self.dofdesc = as_dofdesc(dofdesc).copy(_is_flattened=True)
 
     def __getinitargs__(self):
-        return (self.operand,)
+        return (self.operand, self.dofdesc)
 
     mapper_method = intern("map_flatten")
 
@@ -1148,19 +1156,25 @@ def weights_and_area_elements(ambient_dim, dim=None, dofdesc=None):
 
 def _flat_nodes(ambient_dim, dofdesc=None):
     return cse(
-            _Flatten(nodes(ambient_dim, dofdesc=dofdesc).as_vector()),
+            _Flatten(
+                nodes(ambient_dim, dofdesc=dofdesc).as_vector(),
+                dofdesc),
             scope=cse_scope.DISCRETIZATION)
 
 
 def _flat_expansion_radii(ambient_dim, dim=None, dofdesc=None):
     return cse(
-            _Flatten(expansion_radii(ambient_dim, dim=dim, dofdesc=dofdesc)),
+            _Flatten(
+                expansion_radii(ambient_dim, dim=dim, dofdesc=dofdesc),
+                dofdesc),
             scope=cse_scope.DISCRETIZATION)
 
 
 def _flat_expansion_centers(ambient_dim, side, dim=None, dofdesc=None):
     return cse(
-            _Flatten(expansion_centers(ambient_dim, side, dim=dim, dofdesc=dofdesc)),
+            _Flatten(
+                expansion_centers(ambient_dim, side, dim=dim, dofdesc=dofdesc),
+                dofdesc),
             scope=cse_scope.DISCRETIZATION)
 
 # }}}

--- a/test/extra_int_eq_data.py
+++ b/test/extra_int_eq_data.py
@@ -40,7 +40,8 @@ def make_circular_point_group(ambient_dim, npoints, radius,
     return result
 
 
-def make_source_and_target_points(side, inner_radius, outer_radius, ambient_dim,
+def make_source_and_target_points(
+        actx, side, inner_radius, outer_radius, ambient_dim,
         nsources=10, ntargets=20):
     if side == -1:
         test_src_geo_radius = outer_radius
@@ -58,12 +59,14 @@ def make_source_and_target_points(side, inner_radius, outer_radius, ambient_dim,
     point_sources = make_circular_point_group(
             ambient_dim, nsources, test_src_geo_radius,
             func=lambda x: x**1.5)
-    point_source = PointPotentialSource(point_sources)
+    point_source = PointPotentialSource(
+            actx.freeze(actx.from_numpy(point_sources)))
 
     from pytential.target import PointsTarget
     test_targets = make_circular_point_group(
             ambient_dim, ntargets, test_tgt_geo_radius)
-    point_target = PointsTarget(test_targets)
+    point_target = PointsTarget(
+        actx.freeze(actx.from_numpy(test_targets)))
 
     return point_source, point_target
 

--- a/test/test_layer_pot.py
+++ b/test/test_layer_pot.py
@@ -119,7 +119,7 @@ def test_off_surface_eval(ctx_factory, use_fmm, visualize=False):
 
     from pytential.target import PointsTarget
     fplot = FieldPlotter(np.zeros(2), extent=0.54, npoints=30)
-    targets = PointsTarget(fplot.points)
+    targets = PointsTarget(actx.freeze(actx.from_numpy(fplot.points)))
 
     places = GeometryCollection((qbx, targets))
     density_discr = places.get_discretization(places.auto_source.geometry)
@@ -188,7 +188,7 @@ def test_off_surface_eval_vs_direct(ctx_factory,  do_plot=False):
 
     fplot = FieldPlotter(np.zeros(2), extent=5, npoints=500)
     from pytential.target import PointsTarget
-    ptarget = PointsTarget(fplot.points)
+    ptarget = PointsTarget(actx.freeze(actx.from_numpy(fplot.points)))
     from sumpy.kernel import LaplaceKernel
 
     places = GeometryCollection({
@@ -276,7 +276,7 @@ def test_single_plus_double_with_single_fmm(ctx_factory,  do_plot=False):
 
     fplot = FieldPlotter(np.zeros(2), extent=5, npoints=500)
     from pytential.target import PointsTarget
-    ptarget = PointsTarget(fplot.points)
+    ptarget = PointsTarget(actx.freeze(actx.from_numpy(fplot.points)))
     from sumpy.kernel import LaplaceKernel
 
     places = GeometryCollection({

--- a/test/test_scalar_int_eq.py
+++ b/test/test_scalar_int_eq.py
@@ -73,7 +73,7 @@ def run_int_eq_test(actx: PyOpenCLArrayContext,
     # {{{ construct geometries
 
     qbx = case.get_layer_potential(actx, resolution, case.target_order)
-    point_source, point_target = inteq.make_source_and_target_points(
+    point_source, point_target = inteq.make_source_and_target_points(actx,
             case.side, case.inner_radius, case.outer_radius, qbx.ambient_dim)
 
     places = {

--- a/test/test_stokes.py
+++ b/test/test_stokes.py
@@ -92,6 +92,7 @@ def run_exterior_stokes(ctx_factory, *,
 
     from extra_int_eq_data import make_source_and_target_points
     point_source, point_target = make_source_and_target_points(
+            actx,
             side=+1,
             inner_radius=0.5 * radius,
             outer_radius=2.0 * radius,


### PR DESCRIPTION
This is supposed to help a bit with Stokes until #29 and friends is in. It adds a few small things that seemed to help make it faster

* ~~A `flatten` symbolic function, which is mainly used as a way to cache the required flattened geometry inside the `GeometryCollection`.~~ Cached the flattened nodes, expansion radii and centers in the `GeometryCollection` using `memoize_in` directly.
* ~~Calling `BoundExpression` directly instead of `bind` because `_prepare_expr` showed up significantly. This is fine because in `exec_compute_potential_insn_direct` we already tag everything and don't have any `IntG`, so there's no need for the preprocessing.~~ (turns out this was a very small save, if any)
* In `BoundExpression`, make the call to `OperatorCompiler` lazy and add an early exist in `eval` when the expression is a `cse` scoped on the discretization. Not sure this helped much, but it made the tree in vmprof smaller!

The biggest save came from redoing the `for o in insn.outputs` loop. From what I understand, `sumpy.qbx.LayerPotential` can compute all the target kernels at once now, but that loop computed them all for each element in `insn.outputs` and then just took the one in `o.target_kernel_index` (effectively redoing the computations loads of times).

This probably still needs a bit of testing to make sure nothing is broken, but it seems to help quite a lot, i.e. it went from around 100s to around 10s on a benchmark script I was playing with.

TODO
- [x] Needs inducer/sumpy#41
- [x] Point `requirements.txt` back to sumpy master