### PR TITLE
Check matrix conditioning

### DIFF
--- a/test/extra_matrix_data.py
+++ b/test/extra_matrix_data.py
@@ -80,9 +80,12 @@ class MatrixTestCaseMixin:
         kwargs = self.knl_sym_kwargs.copy()
         kwargs["qbx_forced_limit"] = qbx_forced_limit
 
-        if self.op_type == "scalar":
+        if self.op_type in ("scalar", "single"):
             sym_u = sym.var("u")
             sym_op = sym.S(knl, sym_u, **kwargs)
+        elif self.op_type == "double":
+            sym_u = sym.var("u")
+            sym_op = sym.D(knl, sym_u, **kwargs)
         elif self.op_type == "scalar_mixed":
             sym_u = sym.var("u")
             sym_op = sym.S(knl, 0.3 * sym_u, **kwargs) \
@@ -99,7 +102,9 @@ class MatrixTestCaseMixin:
         else:
             raise ValueError(f"unknown operator type: '{self.op_type}'")
 
-        sym_op = 0.5 * sym_u + sym_op
+        if self.side is not None:
+            sym_op = 0.5 * self.side * sym_u + sym_op
+
         return sym_u, sym_op
 
 


### PR DESCRIPTION
The condition number for `0.5 * u + D(u, "avg")` seems to be huge when constructing the matrix with `pytential.symbolic.execute.build_matrix`, but it's not for `-0.5 * u + D(u, "avg")`.

@inducer 