### PR TITLE
Failing matrix evaluation with target derivatives

### DIFF
--- a/test/test_matrix.py
+++ b/test/test_matrix.py
@@ -86,12 +86,18 @@ def test_target_derivative_sumpy(ctx_factory):
             qbx_forced_limit="avg", **case.knl_sym_kwargs)
 
     from pytential.symbolic.execution import build_matrix
-    mat = build_matrix(
-            actx, places, sym_op, sym_u,
-            context=case.knl_concrete_kwargs,
-            )
+    with pytest.raises(ValueError):
+        build_matrix(
+                actx, places, sym_op, sym_u,
+                context=case.knl_concrete_kwargs,
+                )
 
-    assert mat is not None
+    from meshmode.dof_array import thaw
+    with pytest.raises(ValueError):
+        density_discr = places.get_discretization(case.name)
+        u = thaw(actx, density_discr.nodes()[0])
+
+        bind(places, sym_op)(actx, u=u)
 
     # }}}
 


### PR DESCRIPTION
This now triggers the exception from [sumpy](https://github.com/inducer/sumpy/blob/fbd0b8e18dde5ee1350b38d844464565c863ce2f/sumpy/expansion/local.py#L107-L109). Not quite sure what the right fix is, but there's a `LineTaylorLocalExpansion` in the [matrix evaluation](https://github.com/inducer/pytential/blob/062dd89597b1b1ae2d4bcf8b4c6db1db72ac7466/pytential/symbolic/matrix.py#L381-L383).

@inducer Suggestions?