### PR TITLE
Drop symengine version requirement in .test-conda-env-py3.yml

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -18,7 +18,7 @@ dependencies:
 - islpy
 - pyopencl
 - python=3
-- python-symengine=0.6.0
+- python-symengine
 - pyfmmlib
 - cython
 - gmsh


### PR DESCRIPTION
Trying to deal with https://gitlab.tiker.net/inducer/pytential/-/jobs/271375. Something is forcing the stack onto Py3.8, and this was the hottest candidate I was able to come up with.