### PR TITLE
Improve proxy generator

### DIFF
--- a/pytential/linalg/proxy.py
+++ b/pytential/linalg/proxy.py
@@ -40,6 +40,7 @@ __doc__ = """
 Proxy Point Generation
 ~~~~~~~~~~~~~~~~~~~~~~
 
+.. autoclass:: BlockProxyPoints
 .. autoclass:: ProxyGeneratorBase
 .. autoclass:: ProxyGenerator
 .. autoclass:: QBXProxyGenerator
@@ -442,7 +443,10 @@ def make_compute_block_radii_knl(actx: PyOpenCLArrayContext, ndim: int):
 class ProxyGenerator(ProxyGeneratorBase):
     """A proxy point generator that only considers the points in the current
     block when determining the radius of the proxy ball.
+
+    Inherits from :class:`ProxyGeneratorBase`.
     """
+
     def get_radii_knl(self, actx):
         return make_compute_block_radii_knl(actx, self.ambient_dim)
 
@@ -503,7 +507,10 @@ def make_compute_block_qbx_radii_knl(actx: PyOpenCLArrayContext, ndim: int):
 class QBXProxyGenerator(ProxyGeneratorBase):
     """A proxy point generator that also considers the QBX expansion
     when determining the radius of the proxy ball.
+
+    Inherits from :class:`ProxyGeneratorBase`.
     """
+
     def get_radii_knl(self, actx):
         return make_compute_block_qbx_radii_knl(actx, self.ambient_dim)
 

--- a/test/extra_int_eq_data.py
+++ b/test/extra_int_eq_data.py
@@ -250,6 +250,8 @@ class IntegralEquationTestCase(RecordWithoutPickling):
 # {{{ 2d curves
 
 class CurveTestCase(IntegralEquationTestCase):
+    ambient_dim = 2
+
     # qbx
     qbx_order = 5
     target_order = 5
@@ -295,6 +297,8 @@ class CircleTestCase(EllipseTestCase):
 # {{{ 3d surfaces
 
 class Helmholtz3DTestCase(IntegralEquationTestCase):
+    ambient_dim = 3
+
     # qbx
     use_refinement = False
 
@@ -335,6 +339,7 @@ class HelmholtzEllisoidTestCase(Helmholtz3DTestCase):
 
 
 class SphereTestCase(IntegralEquationTestCase):
+    ambient_dim = 3
     name = "sphere"
 
     # qbx
@@ -363,6 +368,7 @@ class SphereTestCase(IntegralEquationTestCase):
 
 
 class TorusTestCase(IntegralEquationTestCase):
+    ambient_dim = 3
     name = "torus"
 
     # qbx
@@ -457,6 +463,7 @@ class ManyEllipsoidTestCase(Helmholtz3DTestCase):
 # {{{ fancy geometries
 
 class EllipticPlaneTestCase(IntegralEquationTestCase):
+    ambient_dim = 3
     name = "elliptic_plane"
 
     # qbx
@@ -504,6 +511,7 @@ class EllipticPlaneTestCase(IntegralEquationTestCase):
 
 
 class BetterPlaneTestCase(IntegralEquationTestCase):
+    ambient_dim = 3
     name = "better_plane"
 
     # qbx

--- a/test/extra_matrix_data.py
+++ b/test/extra_matrix_data.py
@@ -47,7 +47,7 @@ class MatrixTestCaseMixin:
         from pytential.linalg.proxy import partition_by_nodes
         indices = partition_by_nodes(actx, discr,
                 tree_kind=self.tree_kind,
-                max_nodes_in_box=max_particles_in_box)
+                max_particles_in_box=max_particles_in_box)
 
         if abs(self.index_sparsity_factor - 1.0) < 1.0e-14:
             if not matrix_indices:

--- a/test/extra_matrix_data.py
+++ b/test/extra_matrix_data.py
@@ -33,6 +33,10 @@ class MatrixTestCaseMixin:
     tree_kind = "adaptive-level-restricted"
     index_sparsity_factor = 1.0
 
+    # proxy
+    proxy_radius_factor = 1.1
+    proxy_approx_count = 32
+
     # operators
     op_type = "scalar"
 

--- a/test/test_linalg_proxy.py
+++ b/test/test_linalg_proxy.py
@@ -42,7 +42,6 @@ from pyopencl.tools import (  # noqa
 import extra_matrix_data as extra
 import logging
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 
 # {{{ visualize proxy geometry

--- a/test/test_linalg_proxy.py
+++ b/test/test_linalg_proxy.py
@@ -278,13 +278,9 @@ def test_interaction_points(ctx_factory,
     _, _, pxycenters, pxyradii = generator(actx, places.auto_source, srcindices)
 
     # get neighboring points
-    from pytential.linalg.proxy import (  # noqa
-            gather_block_neighbor_points,
-            gather_block_interaction_points)
+    from pytential.linalg.proxy import gather_block_neighbor_points
     nbrindices = gather_block_neighbor_points(actx, density_discr,
             srcindices, pxycenters, pxyradii)
-    nodes, ranges = gather_block_interaction_points(actx,
-            places, places.auto_source, srcindices)
 
     srcindices = srcindices.get(queue)
     nbrindices = nbrindices.get(queue)
@@ -305,27 +301,18 @@ def test_interaction_points(ctx_factory,
         ambient_dim = places.ambient_dim
         if ambient_dim == 2:
             import matplotlib.pyplot as pt
-            density_nodes = flatten_to_numpy(actx, density_discr.nodes())
-            nodes = flatten_to_numpy(actx, nodes)
-            ranges = actx.to_numpy(ranges)
+            nodes = flatten_to_numpy(actx, density_discr.nodes())
+            iall = srcindices.indices
 
             for i in range(srcindices.nblocks):
                 isrc = srcindices.block_indices(i)
                 inbr = nbrindices.block_indices(i)
-                iall = np.s_[ranges[i]:ranges[i + 1]]
 
                 pt.figure(figsize=(10, 8))
-                pt.plot(density_nodes[0], density_nodes[1],
-                        "ko", ms=2.0, alpha=0.5)
-                pt.plot(density_nodes[0][srcindices.indices],
-                        density_nodes[1][srcindices.indices],
-                        "o", ms=2.0)
-                pt.plot(density_nodes[0][isrc], density_nodes[1][isrc],
-                        "o", ms=2.0)
-                pt.plot(density_nodes[0][inbr], density_nodes[1][inbr],
-                        "o", ms=2.0)
-                pt.plot(nodes[0][iall], nodes[1][iall],
-                        "x", ms=2.0)
+                pt.plot(nodes[0], nodes[1], "ko", ms=2.0, alpha=0.5)
+                pt.plot(nodes[0][iall], nodes[1][iall], "o", ms=2.0)
+                pt.plot(nodes[0][isrc], nodes[1][isrc], "o", ms=2.0)
+                pt.plot(nodes[0][inbr], nodes[1][inbr], "o", ms=2.0)
                 pt.xlim([-1.5, 1.5])
                 pt.ylim([-1.5, 1.5])
 

--- a/test/test_linalg_proxy.py
+++ b/test/test_linalg_proxy.py
@@ -45,6 +45,8 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
+# {{{ visualize proxy geometry
+
 def plot_proxy_geometry(
         actx, places, indices, pxy=None, nbrindices=None, with_qbx_centers=False,
         suffix=None):
@@ -165,6 +167,8 @@ def plot_proxy_geometry(
     else:
         raise ValueError
 
+# }}}
+
 
 PROXY_TEST_CASES = [
         extra.CurveTestCase(
@@ -181,6 +185,8 @@ PROXY_TEST_CASES = [
             resolutions=[0])
         ]
 
+
+# {{{ test_partition_points
 
 @pytest.mark.parametrize("tree_kind", ["adaptive", None])
 @pytest.mark.parametrize("case", PROXY_TEST_CASES)
@@ -218,6 +224,10 @@ def test_partition_points(ctx_factory, tree_kind, case, visualize=True):
     plot_proxy_geometry(actx, places, indices,
             suffix=f"{tree_kind}_{case.ambient_dim}d".lower())
 
+# }}}
+
+
+# {{{ test_proxy_generator
 
 @pytest.mark.parametrize("proxy_generator_cls", [
     ProxyGenerator, QBXProxyGenerator,
@@ -268,6 +278,10 @@ def test_proxy_generator(ctx_factory,
             suffix=f"generator_{index_sparsity_factor:.2f}",
             )
 
+# }}}
+
+
+# {{{ test_neighbor_points
 
 @pytest.mark.parametrize("proxy_generator_cls", [
     ProxyGenerator, QBXProxyGenerator,
@@ -321,6 +335,8 @@ def test_neighbor_points(ctx_factory,
             actx, places, srcindices, nbrindices=nbrindices,
             suffix=f"neighbor_{index_sparsity_factor:.2f}",
             )
+
+# }}}
 
 
 if __name__ == "__main__":

--- a/test/test_linalg_proxy.py
+++ b/test/test_linalg_proxy.py
@@ -256,7 +256,7 @@ def test_proxy_generator(ctx_factory,
     ])
 @pytest.mark.parametrize("case", PROXY_TEST_CASES)
 @pytest.mark.parametrize("index_sparsity_factor", [1.0, 0.6])
-def test_interaction_points(ctx_factory,
+def test_neighbor_points(ctx_factory,
         proxy_generator_cls, case, index_sparsity_factor, visualize=False):
     """Test that neighboring points (inside the proxy balls, but outside the
     current block/cluster) are actually inside.
@@ -283,8 +283,7 @@ def test_interaction_points(ctx_factory,
 
     # get neighboring points
     from pytential.linalg.proxy import gather_block_neighbor_points
-    nbrindices = gather_block_neighbor_points(actx, density_discr,
-            srcindices, pxy.centers, pxy.radii)
+    nbrindices = gather_block_neighbor_points(actx, density_discr, pxy)
 
     srcindices = srcindices.get(queue)
     nbrindices = nbrindices.get(queue)


### PR DESCRIPTION
This takes out another chunk out of #30 that just changes the proxy generator. The bigger changes are
* Separated out a `ProxyGenerator`, that ignores any QBX expansions, and a `QBXProxyGenerator`, that makes proxies outside of the QBX expansions.
* Separated the loopy kernels that get centers and radii to make the proxy balls. Also split some inames and things, but that probably requires a careful (and knowledgeable) look.
* removed unused `gather_block_interaction_points`, which was meant to just make a big array of neighbors + proxies to be evaluated together.
* cleaned up the tests a bit and added some more checks.

Looking at the diff, it looks a bit big, but it should just be moving things around.