### PR TITLE
Import and update BlockIndexRanges from sumpy

### DIFF
--- a/doc/linalg.rst
+++ b/doc/linalg.rst
@@ -4,6 +4,12 @@ Linear Algebra Routines
 Hierarchical Direct Solver
 --------------------------
 
+.. warning::
+
+    All the classes and routines in this module are experimental and the
+    API can change at any point.
+
 .. automodule:: pytential.linalg.proxy
+.. automodule:: pytential.linalg.utils
 
 .. vim: sw=4:tw=75

--- a/pytential/linalg/__init__.py
+++ b/pytential/linalg/__init__.py
@@ -19,3 +19,22 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
+
+from pytential.linalg.proxy import (
+        BlockProxyPoints, ProxyGeneratorBase,
+        ProxyGenerator, QBXProxyGenerator,
+        partition_by_nodes, gather_block_neighbor_points,
+        )
+from pytential.linalg.utils import (
+        BlockIndexRanges, MatrixBlockIndexRanges,
+        make_block_index_from_array, make_index_blockwise_product,
+        )
+
+__all__ = (
+    "BlockProxyPoints", "ProxyGeneratorBase",
+    "ProxyGenerator", "QBXProxyGenerator",
+    "partition_by_nodes", "gather_block_neighbor_points",
+
+    "BlockIndexRanges", "MatrixBlockIndexRanges",
+    "make_block_index_from_array", "make_index_blockwise_product",
+)

--- a/pytential/linalg/proxy.py
+++ b/pytential/linalg/proxy.py
@@ -30,7 +30,7 @@ from arraycontext import PyOpenCLArrayContext
 from meshmode.discretization import Discretization
 
 from pytools import memoize_in
-from sumpy.tools import BlockIndexRanges
+from pytential.linalg.utils import BlockIndexRanges
 
 import loopy as lp
 from loopy.version import MOST_RECENT_LANGUAGE_VERSION
@@ -39,6 +39,8 @@ from loopy.version import MOST_RECENT_LANGUAGE_VERSION
 __doc__ = """
 Proxy Point Generation
 ~~~~~~~~~~~~~~~~~~~~~~
+
+.. currentmodule:: pytential.linalg
 
 .. autoclass:: BlockProxyPoints
 .. autoclass:: ProxyGeneratorBase
@@ -100,7 +102,7 @@ def partition_by_nodes(
         ranges = np.linspace(0, discr.ndofs, nblocks + 1, dtype=np.int64)
         assert ranges[-1] == discr.ndofs
 
-    from pytential.linalg.utils import make_block_index_from_array
+    from pytential.linalg import make_block_index_from_array
     return make_block_index_from_array(indices, ranges=ranges)
 
 # }}}
@@ -159,12 +161,12 @@ class BlockProxyPoints:
     """
     .. attribute:: srcindices
 
-        A :class:`~sumpy.tools.BlockIndexRanges` describing which block of
+        A :class:`~pytential.linalg.BlockIndexRanges` describing which block of
         points each proxy ball was created from.
 
     .. attribute:: indices
 
-        A :class:`~sumpy.tools.BlockIndexRanges` describing which proxies
+        A :class:`~pytential.linalg.BlockIndexRanges` describing which proxies
         belong to which block.
 
     .. attribute:: points
@@ -203,8 +205,6 @@ class BlockProxyPoints:
         from arraycontext import to_numpy
         from dataclasses import replace
         return replace(self,
-                srcindices=self.srcindices.get(actx.queue),
-                indices=self.indices.get(actx.queue),
                 points=to_numpy(self.points, actx),
                 centers=to_numpy(self.centers, actx),
                 radii=to_numpy(self.radii, actx))
@@ -373,7 +373,7 @@ class ProxyGeneratorBase:
         pxyranges = np.arange(0, nproxy + 1, self.nproxy)
 
         from arraycontext import freeze, from_numpy
-        from pytential.linalg.utils import make_block_index_from_array
+        from pytential.linalg import make_block_index_from_array
         return BlockProxyPoints(
                 srcindices=indices,
                 indices=make_block_index_from_array(pxyindices, pxyranges),
@@ -594,7 +594,7 @@ def gather_block_neighbor_points(
     from arraycontext import to_numpy
     pxycenters = to_numpy(pxy.centers, actx)
     pxyradii = to_numpy(pxy.radii, actx)
-    indices = pxy.srcindices.get(actx.queue)
+    indices = pxy.srcindices
 
     nbrindices = np.empty(indices.nblocks, dtype=object)
     for iproxy in range(indices.nblocks):
@@ -623,7 +623,7 @@ def gather_block_neighbor_points(
 
     # }}}
 
-    from pytential.linalg.utils import make_block_index_from_array
+    from pytential.linalg import make_block_index_from_array
     return make_block_index_from_array(indices=nbrindices)
 
 # }}}

--- a/pytential/linalg/utils.py
+++ b/pytential/linalg/utils.py
@@ -1,0 +1,206 @@
+__copyright__ = "Copyright (C) 2018-2021 Alexandru Fikl"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Tuple
+
+import numpy as np
+
+from arraycontext import PyOpenCLArrayContext
+from pytools import memoize_in
+
+
+# {{{ block index handling
+
+@dataclass(frozen=True)
+class BlockIndexRanges:
+    """Convenience class for working with subsets (blocks) of an array.
+
+    .. attribute:: nblocks
+    .. attribute:: indices
+
+        An :class:`~numpy.ndarray` of not necessarily continuous or increasing
+        integers representing the indices of a global array. The individual
+        blocks are delimited using :attr:`ranges`.
+
+    .. attribute:: ranges
+
+        An :class:`~numpy.ndarray` of size ``(nblocks,)`` consisting of
+        nondecreasing integers used to index into :attr:`indices`. A block
+        :math:`i` can be retrieved using ``indices[ranges[i]:ranges[i + 1]]``.
+
+    .. automethod:: block_size
+    .. automethod:: block_indices
+    .. automethod:: block_take
+    """
+
+    indices: np.ndarray
+    ranges: np.ndarray
+
+    @property
+    def nblocks(self) -> int:
+        return self.ranges.size - 1
+
+    def block_size(self, i: int) -> int:
+        """
+        :returns: the number of indices in the block *i*.
+        """
+        if not (0 <= i < self.nblocks):
+            raise IndexError(f"block {i} is out of bounds for {self.nblocks} blocks")
+
+        return self.ranges[i + 1] - self.ranges[i]
+
+    def block_indices(self, i: int) -> np.ndarray:
+        """
+        :returns: the actual indices in block *i*.
+        """
+        if not (0 <= i < self.nblocks):
+            raise IndexError(f"block {i} is out of bounds for {self.nblocks} blocks")
+
+        return self.indices[self.ranges[i]:self.ranges[i + 1]]
+
+    def block_take(self, x: np.ndarray, i: int) -> np.ndarray:
+        """
+        :returns: a subset of *x* corresponding to the indices in block *i*.
+            The returned array is a copy (not a view) of the elements of *x*.
+        """
+        if not (0 <= i < self.nblocks):
+            raise IndexError(f"block {i} is out of bounds for {self.nblocks} blocks")
+
+        return x[self.block_indices(i)]
+
+
+@dataclass(frozen=True)
+class MatrixBlockIndexRanges:
+    """Convenience class for working with subsets (blocks) of a matrix.
+
+    .. attribute:: nblocks
+    .. attribute:: row
+
+        A :class:`BlockIndexRanges` encapsulating row block indices.
+
+    .. attribute:: col
+
+        A :class:`BlockIndexRanges` encapsulating column block indices.
+
+    .. automethod:: block_shape
+    .. automethod:: block_indices
+    .. automethod:: block_take
+    """
+
+    row: BlockIndexRanges
+    col: BlockIndexRanges
+
+    def __post_init__(self):
+        if self.row.nblocks != self.col.nblocks:
+            raise ValueError("row and column must have the same number of blocks: "
+                    f"got {self.row.nblocks} row blocks "
+                    f"and {self.col.nblocks} column blocks")
+
+    @property
+    def nblocks(self):
+        return self.row.nblocks
+
+    def block_shape(self, i: int, j: int) -> Tuple[int, int]:
+        r"""
+        :returns: the shape of the block ``(i, j)``, where *i* indexes into
+            the :attr:`row`\ s and *j* into the :attr:`col`\ s.
+        """
+        return (self.row.block_size(i), self.col.block_size(j))
+
+    def block_indices(self, i: int, j: int) -> Tuple[np.ndarray, np.ndarray]:
+        """
+        :returns: the indices that make up the block ``(i, j)`` in the matrix.
+        """
+        return (self.row.block_indices(i), self.col.block_indices(j))
+
+    def block_take(self, x: np.ndarray, i: int, j: int) -> np.ndarray:
+        """
+        :returns: a subset of the matrix *x* corresponding to the indices in
+            the block ``(i, j)``. The returned array is a copy of the elements
+            of *x*.
+        """
+        irow, icol = self.block_indices(i, j)
+        return x[np.ix_(irow, icol)]
+
+
+def make_index_blockwise_product(
+        actx: PyOpenCLArrayContext,
+        idx: MatrixBlockIndexRanges) -> Tuple[Any, Any]:
+    """Constructs a Cartesian product of all the indices in *idx* block by block.
+
+    The indices in the resulting arrays are laid out in *C* order. Retrieving
+    """
+    @memoize_in(actx, (make_index_blockwise_product, "index_set_product_knl"))
+    def prg():
+        import loopy as lp
+        from loopy.version import MOST_RECENT_LANGUAGE_VERSION
+
+        knl = lp.make_kernel([
+            "{[irange]: 0 <= irange < nranges}",
+            "{[i, j]: 0 <= i < nrows and 0 <= j < ncols}"
+            ],
+            """
+            for irange
+                <> nrows = rowranges[irange + 1] - rowranges[irange]
+                <> ncols = colranges[irange + 1] - colranges[irange]
+                <> offset = rowranges[irange] * colranges[irange]
+
+                for i, j
+                    rowindices[offset + ncols * i + j] = \
+                            rowindices[rowranges[irange] + i] \
+                            {id_prefix=write_index}
+                    colindices[offset + ncols * i + j] = \
+                            colindices[colranges[irange] + j] \
+                            {id_prefix=write_index}
+                end
+            end
+            """, [
+                lp.GlobalArg("rowindices", None, shape="nresults"),
+                lp.GlobalArg("colindices", None, shape="nresults"),
+                lp.ValueArg("nresults", None),
+                ...
+                ],
+            name="index_set_product_knl",
+            default_offset=lp.auto,
+            assumptions="nranges>=1",
+            silenced_warnings="write_race(write_index*)",
+            lang_version=MOST_RECENT_LANGUAGE_VERSION)
+
+        knl = lp.split_iname(knl, "irange", 128, outer_tag="g.0")
+        return knl
+
+    @memoize_in(idx, (make_index_blockwise_product, "index_set_product"))
+    def _make_product():
+        _, (rowindices, colindices) = prg()(actx.queue,
+                rowindices=actx.from_numpy(idx.row.indices),
+                rowranges=actx.from_numpy(idx.row.ranges),
+                colindices=actx.from_numpy(idx.col.indices),
+                colranges=actx.from_numpy(idx.col.ranges),
+                nresults=idx.row.indices.size * idx.col.indices.size,
+                )
+
+        return actx.freeze(rowindices), actx.freeze(colindices)
+
+    return _make_product()
+
+# }}}

--- a/pytential/linalg/utils.py
+++ b/pytential/linalg/utils.py
@@ -21,7 +21,7 @@ THE SOFTWARE.
 """
 
 from dataclasses import dataclass
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 import numpy as np
 
@@ -141,6 +141,25 @@ class MatrixBlockIndexRanges:
         """
         irow, icol = self.block_indices(i, j)
         return x[np.ix_(irow, icol)]
+
+
+def make_block_index_from_array(
+        indices: np.ndarray,
+        ranges: Optional[np.ndarray] = None) -> BlockIndexRanges:
+    """Wrap a ``(indices, ranges)`` tuple into a ``BlockIndexRanges``.
+
+    :param ranges: if *None*, then *indices* is expected to be an object
+        array of indices, so that the ranges can be reconstructed.
+    """
+    if ranges is None:
+        ranges = np.cumsum([0] + [r.size for r in indices])
+        indices = np.hstack(indices)
+    else:
+        if ranges[-1] != indices.size:
+            raise ValueError("size of 'indices' does not match 'ranges' endpoint; "
+                    f"expected {indices.size}, but got {ranges[-1]}")
+
+    return BlockIndexRanges(indices=indices, ranges=ranges)
 
 
 def make_index_blockwise_product(

--- a/pytential/symbolic/matrix.py
+++ b/pytential/symbolic/matrix.py
@@ -290,7 +290,7 @@ class MatrixBlockBuilderBase(MatrixBuilderBase):
     def is_kind_matrix(self, x):
         # NOTE: since matrices are flattened, we recognize them by checking
         # if they have the right size
-        return x.size == self.index_set._size
+        return x.size == self.index_set._total_size
 
 
 class MatrixBlockBuilderWithoutComposition(MatrixBlockBuilderBase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ git+https://github.com/inducer/loopy.git#egg=loopy
 git+https://github.com/inducer/boxtree.git#egg=boxtree
 git+https://github.com/inducer/arraycontext.git#egg=arraycontext
 git+https://github.com/inducer/meshmode.git#egg=meshmode
-git+https://github.com/inducer/sumpy.git#egg=sumpy
+git+https://github.com/alexfikl/sumpy.git@remove-block-index-ranges#egg=sumpy
 git+https://github.com/inducer/pyfmmlib.git#egg=pyfmmlib

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,5 @@ git+https://github.com/inducer/loopy.git#egg=loopy
 git+https://github.com/inducer/boxtree.git#egg=boxtree
 git+https://github.com/inducer/arraycontext.git#egg=arraycontext
 git+https://github.com/inducer/meshmode.git#egg=meshmode
-git+https://github.com/alexfikl/sumpy.git@remove-block-index-ranges#egg=sumpy
+git+https://github.com/inducer/sumpy.git#egg=sumpy
 git+https://github.com/inducer/pyfmmlib.git#egg=pyfmmlib

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,7 +10,7 @@ docstring-quotes = """
 multiline-quotes = """
 
 # enable-flake8-bugbear
-#
+
 [tool:pytest]
 markers=
     slowtest: mark a test as slow

--- a/test/test_linalg_utils.py
+++ b/test/test_linalg_utils.py
@@ -53,7 +53,7 @@ def test_matrix_block_index(ctx_factory):
     rng = np.random.default_rng()
     mat = rng.random(size=(npoints, npoints))
 
-    from pytential.linalg.utils import BlockIndexRanges, MatrixBlockIndexRanges
+    from pytential.linalg import BlockIndexRanges, MatrixBlockIndexRanges
     row = BlockIndexRanges(indices, ranges)
     col = BlockIndexRanges(indices, ranges)
     idx = MatrixBlockIndexRanges(row, col)
@@ -62,17 +62,14 @@ def test_matrix_block_index(ctx_factory):
 
     # {{{ check the cartesian product
 
-    from pytential.linalg.utils import make_index_blockwise_product
+    from pytential.linalg import make_index_blockwise_product
     rowindices, colindices = make_index_blockwise_product(actx, idx)
     rowindices = actx.to_numpy(rowindices)
     colindices = actx.to_numpy(colindices)
-    offsets = np.cumsum([0] + [
-        idx.row.block_size(i) * idx.col.block_size(i) for i in range(idx.nblocks)
-        ])
 
+    ranges = idx._block_ranges
     for i in range(idx.nblocks):
-        istart = offsets[i]
-        iend = offsets[i + 1]
+        istart, iend = ranges[i:i + 2]
 
         blk_ref = idx.block_take(mat, i, i)
         blk = mat[rowindices[istart:iend], colindices[istart:iend]].reshape(

--- a/test/test_linalg_utils.py
+++ b/test/test_linalg_utils.py
@@ -1,0 +1,93 @@
+__copyright__ = "Copyright (C) 2021 Alexandru Fikl"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+import numpy as np
+import numpy.linalg as la
+
+import pyopencl as cl
+from arraycontext import PyOpenCLArrayContext
+
+import pytest
+from pyopencl.tools import (  # noqa
+        pytest_generate_tests_for_pyopencl
+        as pytest_generate_tests)
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+# {{{ test_matrix_block_index
+
+def test_matrix_block_index(ctx_factory):
+    ctx = ctx_factory()
+    queue = cl.CommandQueue(ctx)
+    actx = PyOpenCLArrayContext(queue)
+
+    # {{{ setup
+
+    npoints = 256
+    nblocks = 12
+
+    indices = np.arange(0, npoints)
+    ranges = np.linspace(0, npoints, nblocks + 1, dtype=np.int64)
+
+    rng = np.random.default_rng()
+    mat = rng.random(size=(npoints, npoints))
+
+    from pytential.linalg.utils import BlockIndexRanges, MatrixBlockIndexRanges
+    row = BlockIndexRanges(indices, ranges)
+    col = BlockIndexRanges(indices, ranges)
+    idx = MatrixBlockIndexRanges(row, col)
+
+    # }}}
+
+    # {{{ check the cartesian product
+
+    from pytential.linalg.utils import make_index_blockwise_product
+    rowindices, colindices = make_index_blockwise_product(actx, idx)
+    rowindices = actx.to_numpy(rowindices)
+    colindices = actx.to_numpy(colindices)
+    offsets = np.cumsum([0] + [
+        idx.row.block_size(i) * idx.col.block_size(i) for i in range(idx.nblocks)
+        ])
+
+    for i in range(idx.nblocks):
+        istart = offsets[i]
+        iend = offsets[i + 1]
+
+        blk_ref = idx.block_take(mat, i, i)
+        blk = mat[rowindices[istart:iend], colindices[istart:iend]].reshape(
+                idx.block_shape(i, i))
+
+        assert la.norm(blk - blk_ref) < 1.0e-15 * la.norm(blk_ref)
+
+    # }}}
+
+# }}}
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        pytest.main([__file__])


### PR DESCRIPTION
These are removed from sumpy in inducer/sumpy#65.

This PR also reworks `BlockIndexRanges` a bit. Before the indices and ranges were `cl.array.Array`, which resulted in a lot of back and forth (when skeletonizing in #30), so now they're just `ndarray`. The arrays passed on to sumpy are still constructed as `cl.array.Array`.

- [x] Depends on inducer/sumpy#65
- [x] Point `requirements.txt` back to main sumpy.