### PR TITLE
Fix some array context mismatching

### DIFF
--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -342,6 +342,7 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
         def make_container():
             from pytential.qbx.utils import TreeCodeContainer
             return TreeCodeContainer(self._setup_actx)
+
         return make_container()
 
     @property
@@ -352,6 +353,7 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
             from pytential.qbx.refinement import RefinerCodeContainer
             return RefinerCodeContainer(
                     self._setup_actx, self.tree_code_container)
+
         return make_container()
 
     @property
@@ -362,13 +364,13 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
             from pytential.qbx.target_assoc import TargetAssociationCodeContainer
             return TargetAssociationCodeContainer(
                     self._setup_actx, self.tree_code_container)
+
         return make_container()
 
     @property
     def qbx_fmm_geometry_data_code_container(self):
         @memoize_in(self._setup_actx, (
-                QBXLayerPotentialSource,
-                "qbx_fmm_geometry_data_code_container"))
+                QBXLayerPotentialSource, "qbx_fmm_geometry_data_code_container"))
         def make_container(
                 debug, ambient_dim, well_sep_is_n_away,
                 from_sep_smaller_crit):

--- a/pytential/source.py
+++ b/pytential/source.py
@@ -248,7 +248,7 @@ class LayerPotentialSourceBase(_SumpyP2PMixin, PotentialSource):
 
     @property
     def cl_context(self):
-        return self.density_discr._setup_actx.context
+        return self._setup_actx.context
 
     @property
     def real_dtype(self):

--- a/pytential/symbolic/dof_connection.py
+++ b/pytential/symbolic/dof_connection.py
@@ -64,10 +64,6 @@ class GranularityConnection:
     def to_discr(self):
         return self.discr
 
-    @property
-    def array_context(self):
-        return self.discr._setup_actx
-
     def __call__(self, ary):
         raise NotImplementedError()
 
@@ -88,62 +84,67 @@ class CenterGranularityConnection(GranularityConnection):
         if not isinstance(ary1, DOFArray) or not isinstance(ary2, DOFArray):
             raise TypeError("non-array passed to connection")
 
-        @memoize_in(self.array_context,
+        if ary1.array_context is not ary2.array_context:
+            raise ValueError("array context of the two arguments must match")
+
+        actx = ary1.array_context
+
+        @memoize_in(actx,
                  (CenterGranularityConnection, "interleave"))
         def prg():
             from arraycontext import make_loopy_program
             return make_loopy_program(
-                    """{[iel, idof]: 0<=iel<nelements and 0<=idof<nunit_dofs}""",
+                    "{[iel, idof]: 0 <= iel < nelements and 0 <= idof < nunit_dofs}",
                     """
-                    dst[iel, 2*idof] = src1[iel, idof]
-                    dst[iel, 2*idof + 1] = src2[iel, idof]
-                    """,
-                    [
-                        lp.GlobalArg("src1", shape="(nelements, nunit_dofs)"),
-                        lp.GlobalArg("src2", shape="(nelements, nunit_dofs)"),
-                        lp.GlobalArg("dst", shape="(nelements, 2*nunit_dofs)"),
-                        "...",
+                    result[iel, 2*idof] = ary1[iel, idof]
+                    result[iel, 2*idof + 1] = ary2[iel, idof]
+                    """, [
+                        lp.GlobalArg("ary1", shape="(nelements, nunit_dofs)"),
+                        lp.GlobalArg("ary2", shape="(nelements, nunit_dofs)"),
+                        lp.GlobalArg("result", shape="(nelements, 2*nunit_dofs)"),
+                        ...
                         ],
                     name="interleave")
 
         results = []
-        for grp, src1, src2 in zip(self.discr.groups, ary1, ary2):
-            if src1.dtype != src2.dtype:
-                raise ValueError("dtype mismatch in inputs")
-            result = self.array_context.empty(
-                    (grp.nelements, 2 * grp.nunit_dofs), dtype=src1.dtype)
-            self.array_context.call_loopy(
-                    prg(), src1=src1, src2=src2, dst=result,
-                    nelements=grp.nelements, nunit_dofs=grp.nunit_dofs)
+        for grp, subary1, subary2 in zip(self.discr.groups, ary1, ary2):
+            if subary1.dtype != subary2.dtype:
+                raise ValueError("dtype mismatch in inputs: "
+                    f"'{subary1.dtype.name}' and '{subary2.dtype.name}'")
+
+            result = actx.call_loopy(
+                    prg(),
+                    ary1=subary1, ary2=subary2,
+                    nelements=grp.nelements,
+                    nunit_dofs=grp.nunit_dofs)["result"]
             results.append(result)
-        return DOFArray(self.array_context, tuple(results))
+
+        return DOFArray(actx, tuple(results))
 
     def __call__(self, arys):
         r"""
-        :arg arys: either a single :class:`~meshmode.dof_array.DOFArray`
-            or a list/tuple with exactly 2 entries that are both
-            :class:`~meshmode.dof_array.DOFArray`\ s.
-            Additionally, this function vectorizes over object arrays of
-            :class:`~meshmode.dof_array.DOFArrays`\ s.
+        :param arys: a pair of :class:`~arraycontext.ArrayContainer`-like
+            classes. Can also be a single element, in which case it is
+            interleaved with itself. This function vectorizes over all the
+            :class:`~meshmode.dof_array.DOFArray` leaves of the container.
 
-        :return: an interleaved array or list of :class:`pyopencl.array.Array`s.
-            If *vecs* was a pair of arrays :math:`(x, y)`, they are
+        :returns: an interleaved :class:`~arraycontext.ArrayContainer`.
+            If *arys* was a pair of arrays :math:`(x, y)`, they are
             interleaved as :math:`[x_1, y_1, x_2, y_2, \ddots, x_n, y_n]`.
-            A single array is simply interleaved with itself.
-
         """
-        if isinstance(arys, DOFArray):
-            arys = (arys, arys)
         if isinstance(arys, (list, tuple)):
-            assert len(arys) == 2
+            ary1, ary2 = arys
         else:
-            raise ValueError("cannot interleave arrays")
+            ary1, ary2 = arys, arys
 
-        if isinstance(arys[0], DOFArray):
-            return self._interleave_dof_arrays(*arys)
-        else:
-            from pytools.obj_array import obj_array_vectorize_n_args
-            return obj_array_vectorize_n_args(self._interleave_dof_arrays, *arys)
+        if type(ary1) is not type(ary2):
+            raise TypeError("cannot interleave arrays of different types: "
+                    f"'{type(ary1).__name__}' and '{type(ary2.__name__)}'")
+
+        from meshmode.dof_array import rec_multimap_dof_array_container
+        return rec_multimap_dof_array_container(
+                self._interleave_dof_arrays,
+                ary1, ary2)
 
 # }}}
 

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -33,7 +33,7 @@ import pyopencl as cl
 import pyopencl.array  # noqa
 import pyopencl.clmath  # noqa
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import PyOpenCLArrayContext, thaw, freeze
 from meshmode.dof_array import DOFArray, flatten
 
 from pytools import memoize_in, memoize_method
@@ -281,10 +281,10 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
             return self.rec(expr.child)
 
         try:
-            rec = cache[expr.child]
+            rec = thaw(cache[expr.child], self.array_context)
         except KeyError:
             rec = self.rec(expr.child)
-            cache[expr.child] = rec
+            cache[expr.child] = freeze(rec, self.array_context)
 
         return rec
 
@@ -1064,7 +1064,7 @@ class BoundExpression:
             cache = self.places._get_cache(EvaluationMapperCSECacheKey)
 
             if self.sym_op_expr.child in cache:
-                return cache[self.sym_op_expr.child]
+                return thaw(cache[self.sym_op_expr.child], array_context)
 
         array_context = _find_array_context_from_args_in_context(
                 context, array_context)

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -280,11 +280,19 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
         else:
             return self.rec(expr.child)
 
+        from numbers import Number
         try:
-            rec = thaw(cache[expr.child], self.array_context)
+            rec = cache[expr.child]
+            if (expr.scope == sym.cse_scope.DISCRETIZATION
+                    and not isinstance(rec, Number)):
+                rec = thaw(rec, self.array_context)
         except KeyError:
-            rec = self.rec(expr.child)
-            cache[expr.child] = freeze(rec, self.array_context)
+            cached_rec = rec = self.rec(expr.child)
+            if (expr.scope == sym.cse_scope.DISCRETIZATION
+                    and not isinstance(rec, Number)):
+                cached_rec = freeze(cached_rec, self.array_context)
+
+            cache[expr.child] = cached_rec
 
         return rec
 
@@ -1063,8 +1071,15 @@ class BoundExpression:
                 and self.sym_op_expr.scope == sym.cse_scope.DISCRETIZATION:
             cache = self.places._get_cache(EvaluationMapperCSECacheKey)
 
-            if self.sym_op_expr.child in cache:
-                return thaw(cache[self.sym_op_expr.child], array_context)
+            from numbers import Number
+            expr = self.sym_op_expr
+            if expr.child in cache:
+                value = cache[expr.child]
+                if (expr.scope == sym.cse_scope.DISCRETIZATION
+                        and not isinstance(value, Number)):
+                    value = thaw(value, array_context)
+
+                return value
 
         array_context = _find_array_context_from_args_in_context(
                 context, array_context)


### PR DESCRIPTION
Following inducer/arraycontext#22.

Found two issues
* the interleaving code was returning an array with the `_setup_actx`,
* all the caching in `EvaluationMapper` stored thawed data.

Hopefully the CI will catch a few more.