### PR TITLE
Update tests for device scalars

### DIFF
--- a/examples/cost.py
+++ b/examples/cost.py
@@ -28,7 +28,8 @@ THE SOFTWARE.
 import numpy as np
 import pyopencl as cl
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from meshmode.array_context import PyOpenCLArrayContext
 
 from pytential import sym, bind
 from pytential.qbx.cost import QBXCostModel
@@ -115,7 +116,7 @@ def get_test_density(actx, density_discr):
 
 def calibrate_cost_model(ctx):
     queue = cl.CommandQueue(ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
     cost_model = QBXCostModel()
 
     model_results = []
@@ -153,7 +154,7 @@ def calibrate_cost_model(ctx):
 
 def test_cost_model(ctx, calibration_params):
     queue = cl.CommandQueue(ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
     cost_model = QBXCostModel()
 
     for lpot_source in test_geometries(actx):

--- a/examples/fmm-error.py
+++ b/examples/fmm-error.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pyopencl as cl
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from meshmode.array_context import PyOpenCLArrayContext
 from meshmode.mesh.generation import (  # noqa
         make_curve_mesh, starfish, ellipse, drop)
 
@@ -15,7 +16,7 @@ def main():
 
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
 
     target_order = 16
     qbx_order = 3

--- a/examples/helmholtz-dirichlet.py
+++ b/examples/helmholtz-dirichlet.py
@@ -3,7 +3,8 @@ import numpy.linalg as la
 import pyopencl as cl
 import pyopencl.clmath  # noqa
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from meshmode.array_context import PyOpenCLArrayContext
 from meshmode.discretization import Discretization
 from meshmode.discretization.poly_element import \
         InterpolatoryQuadratureSimplexGroupFactory
@@ -30,7 +31,7 @@ def main(mesh_name="ellipse", visualize=False):
 
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
 
     from meshmode.mesh.generation import ellipse, make_curve_mesh
     from functools import partial

--- a/examples/laplace-dirichlet-3d.py
+++ b/examples/laplace-dirichlet-3d.py
@@ -3,7 +3,8 @@ import numpy.linalg as la
 import pyopencl as cl
 import pyopencl.clmath  # noqa
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from meshmode.array_context import PyOpenCLArrayContext
 from meshmode.discretization import Discretization
 from meshmode.discretization.poly_element import \
         InterpolatoryQuadratureSimplexGroupFactory
@@ -29,7 +30,7 @@ def main(mesh_name="torus", visualize=False):
 
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
 
     if mesh_name == "torus":
         rout = 10

--- a/examples/layerpot-3d.py
+++ b/examples/layerpot-3d.py
@@ -1,7 +1,8 @@
 import numpy as np
 import pyopencl as cl
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from meshmode.array_context import PyOpenCLArrayContext
 
 from sumpy.visualization import FieldPlotter
 from sumpy.kernel import one_kernel_2d, LaplaceKernel, HelmholtzKernel  # noqa
@@ -21,7 +22,7 @@ def main(mesh_name="ellipsoid"):
 
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
 
     if mesh_name == "ellipsoid":
         cad_file_name = "geometries/ellipsoid.step"

--- a/examples/layerpot.py
+++ b/examples/layerpot.py
@@ -5,7 +5,8 @@ if enable_mayavi:
 import numpy as np
 import pyopencl as cl
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from meshmode.array_context import PyOpenCLArrayContext
 from sumpy.visualization import FieldPlotter
 from sumpy.kernel import one_kernel_2d, LaplaceKernel, HelmholtzKernel  # noqa
 
@@ -27,7 +28,7 @@ def main(curve_fn=starfish, visualize=True):
 
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
 
     from meshmode.mesh.generation import make_curve_mesh
     mesh = make_curve_mesh(

--- a/examples/scaling-study.py
+++ b/examples/scaling-study.py
@@ -2,7 +2,8 @@ import numpy as np
 import pyopencl as cl
 import pyopencl.clmath  # noqa
 
-from arraycontext import PyOpenCLArrayContext, thaw
+from arraycontext import thaw
+from meshmode.array_context import PyOpenCLArrayContext
 from meshmode.discretization import Discretization
 from meshmode.discretization.poly_element import \
         InterpolatoryQuadratureSimplexGroupFactory
@@ -59,7 +60,7 @@ def timing_run(nx, ny, visualize=False):
 
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
 
     mesh = make_mesh(nx=nx, ny=ny, visualize=visualize)
 

--- a/pytential/__init__.py
+++ b/pytential/__init__.py
@@ -109,8 +109,7 @@ def norm(discr, x, p=2):
 
     if p == 2:
         norm_op = _norm_2_op(discr, num_components)
-        from math import sqrt
-        return sqrt(norm_op(integrand=x))
+        return norm_op(integrand=x)**(1/2)
 
     elif p == np.inf or p == "inf":
         norm_op = _norm_inf_op(discr, num_components)

--- a/pytential/qbx/utils.py
+++ b/pytential/qbx/utils.py
@@ -241,7 +241,6 @@ def build_tree_with_qbx_metadata(actx: PyOpenCLArrayContext,
          :class:`~pytential.symbolic.primitives.QBX_SOURCE_STAGE1`.
        * targets from ``targets_list``.
 
-    :arg actx: A :class:`PyOpenCLArrayContext`
     :arg places: An instance of
         :class:`~pytential.symbolic.execution.GeometryCollection`.
     :arg targets_list: A list of :class:`pytential.target.TargetBase`

--- a/pytential/symbolic/dof_connection.py
+++ b/pytential/symbolic/dof_connection.py
@@ -93,7 +93,7 @@ class CenterGranularityConnection(GranularityConnection):
                  (CenterGranularityConnection, "interleave"))
         def prg():
             from arraycontext import make_loopy_program
-            return make_loopy_program(
+            t_unit = make_loopy_program(
                     "{[iel, idof]: 0 <= iel < nelements and 0 <= idof < nunit_dofs}",
                     """
                     result[iel, 2*idof] = ary1[iel, idof]
@@ -105,6 +105,12 @@ class CenterGranularityConnection(GranularityConnection):
                         ...
                         ],
                     name="interleave")
+
+            from meshmode.transform_metadata import (
+                    ConcurrentElementInameTag, ConcurrentDOFInameTag)
+            return lp.tag_inames(t_unit, {
+                "iel": ConcurrentElementInameTag(),
+                "idof": ConcurrentDOFInameTag()})
 
         results = []
         for grp, subary1, subary2 in zip(self.discr.groups, ary1, ary2):

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -124,25 +124,28 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
                 expr)
 
     def map_node_sum(self, expr):
-        # FIXME: make less CL specific
-        queue = self.array_context.queue
-        return sum(
-                cl.array.sum(grp_ary, queue=queue).get()[()]
-                for grp_ary in self.rec(expr.operand))
+        actx = self.array_context
+        result = sum(actx.np.sum(grp_ary) for grp_ary in self.rec(expr.operand))
+        if not actx._force_device_scalars:
+            result = actx.to_numpy(result)[()]
+
+        return result
 
     def map_node_max(self, expr):
-        # FIXME: make less CL specific
-        queue = self.array_context.queue
-        return max(
-                cl.array.max(grp_ary, queue=queue).get()[()]
-                for grp_ary in self.rec(expr.operand))
+        actx = self.array_context
+        result = max(actx.np.max(grp_ary) for grp_ary in self.rec(expr.operand))
+        if not actx._force_device_scalars:
+            result = actx.to_numpy(result)[()]
+
+        return result
 
     def map_node_min(self, expr):
-        # FIXME: make less CL specific
-        queue = self.array_context.queue
-        return min(
-                cl.array.min(grp_ary, queue=queue).get()[()]
-                for grp_ary in self.rec(expr.operand))
+        actx = self.array_context
+        result = min(actx.np.min(grp_ary) for grp_ary in self.rec(expr.operand))
+        if not actx._force_device_scalars:
+            result = actx.to_numpy(result)[()]
+
+        return result
 
     def _map_elementwise_reduction(self, reduction_name, expr):
         @memoize_in(self.places, "elementwise_node_"+reduction_name)

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -100,6 +100,44 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
 
         self.queue = actx.queue
 
+    # {{{ TODO: remove when device scalar broadcasting is fixed
+
+    # NOTE:
+    # * awaiting resolution of https://github.com/inducer/arraycontext/issues/49
+    # * these are only the operations required to pass tests
+
+    def _force_host_scalar(self, arg):
+        if isinstance(arg, cl.array.Array) and arg.shape == ():
+            return self.array_context.to_numpy(arg)[()]
+        elif isinstance(arg, np.ndarray) and arg.shape == ():
+            return arg[()]
+        else:
+            return arg
+
+    def _map_device_scalar_reduction(self, func, expr):
+        return func(
+                self._force_host_scalar(self.rec(child))
+                for child in expr.children)
+
+    def map_sum(self, expr):
+        return self._map_device_scalar_reduction(sum, expr)
+
+    def map_product(self, expr):
+        from pytools import product
+        return self._map_device_scalar_reduction(product, expr)
+
+    def _map_device_scalar_op(self, op, arg1, arg2):
+        return op(
+                self._force_host_scalar(self.rec(arg1)),
+                self._force_host_scalar(self.rec(arg2)))
+
+    def map_quotient(self, expr):
+        import operator
+        return self._map_device_scalar_op(
+                operator.truediv, expr.numerator, expr.denominator)
+
+    # }}}
+
     # {{{ map_XXX
 
     def _map_minmax(self, func, inherited_func, expr):

--- a/test/test_layer_pot.py
+++ b/test/test_layer_pot.py
@@ -540,11 +540,13 @@ def test_3d_jump_relations(actx_factory, relation, visualize=False):
         bound_jump_identity = bind(places, jump_identity_sym)
         jump_identity = bound_jump_identity(actx, density=density)
 
-        h_max = bind(places, sym.h_max(qbx.ambient_dim))(actx)
-        err = (
+        h_max = actx.to_numpy(
+                bind(places, sym.h_max(qbx.ambient_dim))(actx)
+                )
+        err = actx.to_numpy(
                 norm(density_discr, jump_identity, np.inf)
                 / norm(density_discr, density, np.inf))
-        print("ERROR", h_max, err)
+        logging.info("ERROR: h_max %.5e %.5e", h_max, err)
 
         eoc_rec.add_data_point(h_max, err)
 

--- a/test/test_layer_pot_eigenvalues.py
+++ b/test/test_layer_pot_eigenvalues.py
@@ -166,8 +166,10 @@ def test_ellipse_eigenvalues(actx_factory, ellipse_aspect, mode_nr, qbx_order,
             pt.legend()
             pt.show()
 
-        h_max = bind(places, sym.h_max(qbx.ambient_dim))(actx)
-        s_err = (
+        h_max = actx.to_numpy(
+                bind(places, sym.h_max(qbx.ambient_dim))(actx)
+                )
+        s_err = actx.to_numpy(
                 norm(density_discr, s_sigma - s_sigma_ref)
                 / norm(density_discr, s_sigma_ref))
         s_eoc_rec.add_data_point(h_max, s_err)
@@ -197,9 +199,9 @@ def test_ellipse_eigenvalues(actx_factory, ellipse_aspect, mode_nr, qbx_order,
         else:
             d_ref_norm = norm(density_discr, d_sigma_ref)
 
-        d_err = (
-                norm(density_discr, d_sigma - d_sigma_ref)
-                / d_ref_norm)
+        d_err = actx.to_numpy(
+                norm(density_discr, d_sigma - d_sigma_ref) / d_ref_norm
+                )
         d_eoc_rec.add_data_point(h_max, d_err)
 
         # }}}
@@ -215,7 +217,7 @@ def test_ellipse_eigenvalues(actx_factory, ellipse_aspect, mode_nr, qbx_order,
 
             sp_sigma_ref = sp_eigval*sigma
 
-            sp_err = (
+            sp_err = actx.to_numpy(
                     norm(density_discr, sp_sigma - sp_sigma_ref)
                     / norm(density_discr, sigma))
             sp_eoc_rec.add_data_point(h_max, sp_err)
@@ -272,9 +274,9 @@ def test_sphere_eigenvalues(actx_factory, mode_m, mode_n, qbx_order,
     dp_eoc_rec = EOCRecorder()
 
     def rel_err(comp, ref):
-        return (
-                norm(density_discr, comp - ref)
-                / norm(density_discr, ref))
+        return actx.to_numpy(
+                norm(density_discr, comp - ref) / norm(density_discr, ref)
+                )
 
     for nrefinements in [0, 1]:
         from meshmode.mesh.generation import generate_icosphere
@@ -322,7 +324,9 @@ def test_sphere_eigenvalues(actx_factory, mode_m, mode_n, qbx_order,
         s_sigma = s_sigma_op(actx, sigma=ymn)
         s_eigval = 1/(2*mode_n + 1)
 
-        h_max = bind(places, sym.h_max(qbx.ambient_dim))(actx)
+        h_max = actx.to_numpy(
+                bind(places, sym.h_max(qbx.ambient_dim))(actx)
+                )
         s_eoc_rec.add_data_point(h_max, rel_err(s_sigma, s_eigval*ymn))
 
         # }}}

--- a/test/test_layer_pot_identity.py
+++ b/test/test_layer_pot_identity.py
@@ -393,10 +393,12 @@ def test_identity_convergence(actx_factory,  case, visualize=False):
             pt.plot(error)
             pt.show()
 
-        linf_error_norm = norm(density_discr, error, p=np.inf)
-        print("--->", key, linf_error_norm)
+        linf_error_norm = actx.to_numpy(norm(density_discr, error, p=np.inf))
+        logger.info("---> key %s error %.5e", key, linf_error_norm)
 
-        h_max = bind(places, sym.h_max(qbx.ambient_dim))(actx)
+        h_max = actx.to_numpy(
+                bind(places, sym.h_max(qbx.ambient_dim))(actx)
+                )
         eoc_rec.add_data_point(h_max, linf_error_norm)
 
         if visualize:
@@ -412,7 +414,7 @@ def test_identity_convergence(actx_factory,  case, visualize=False):
                 ("error", error),
                 ])
 
-    print(eoc_rec)
+    logger.info("\n%s", eoc_rec)
     tgt_order = case.qbx_order - case.expr.order_drop
     assert eoc_rec.order_estimate() > tgt_order - 1.6
 

--- a/test/test_layer_pot_identity.py
+++ b/test/test_layer_pot_identity.py
@@ -20,32 +20,28 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import pytest
 
 import numpy as np
 import numpy.linalg as la
-import pyopencl as cl
-import pyopencl.clmath  # noqa
-import pytest
-from pyopencl.tools import (  # noqa
-        pytest_generate_tests_for_pyopencl as pytest_generate_tests)
 
-from functools import partial
-from arraycontext import PyOpenCLArrayContext, thaw
-from meshmode.mesh.generation import (  # noqa
-        ellipse, cloverleaf, starfish, drop, n_gon, qbx_peanut, WobblyCircle,
-        NArmedStarfish,
-        make_curve_mesh)
-
-# from sumpy.visualization import FieldPlotter
+from arraycontext import thaw
 from pytential import bind, sym, norm
 from pytential import GeometryCollection
-
+import meshmode.mesh.generation as mgen
 from sumpy.kernel import LaplaceKernel, HelmholtzKernel
+# from sumpy.visualization import FieldPlotter
+
+from meshmode import _acf           # noqa: F401
+from arraycontext import pytest_generate_tests_for_array_contexts
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 
 import logging
 logger = logging.getLogger(__name__)
 
-circle = partial(ellipse, 1)
+pytest_generate_tests = pytest_generate_tests_for_array_contexts([
+    PytestPyOpenCLArrayContextFactory,
+    ])
 
 try:
     import matplotlib.pyplot as pt
@@ -87,8 +83,8 @@ class StarfishGeometry:
     resolutions = [30, 50, 70, 90]
 
     def get_mesh(self, nelements, target_order):
-        return make_curve_mesh(
-                NArmedStarfish(self.n_arms, self.amplitude),
+        return mgen.make_curve_mesh(
+                mgen.NArmedStarfish(self.n_arms, self.amplitude),
                 np.linspace(0, 1, nelements+1),
                 target_order)
 
@@ -100,8 +96,8 @@ class WobblyCircleGeometry:
     resolutions = [2000, 3000, 4000]
 
     def get_mesh(self, resolution, target_order):
-        return make_curve_mesh(
-                WobblyCircle.random(30, seed=30),
+        return mgen.make_curve_mesh(
+                mgen.WobblyCircle.random(30, seed=30),
                 np.linspace(0, 1, resolution+1),
                 target_order)
 
@@ -258,8 +254,8 @@ class DynamicTestCase:
 @pytest.mark.parametrize("case", [
         DynamicTestCase(SphereGeometry(), GreenExpr(), 0),
 ])
-def test_identity_convergence_slow(ctx_factory, case):
-    test_identity_convergence(ctx_factory, case)
+def test_identity_convergence_slow(actx_factory, case):
+    test_identity_convergence(actx_factory, case)
 
 
 @pytest.mark.parametrize("case", [
@@ -277,14 +273,12 @@ def test_identity_convergence_slow(ctx_factory, case):
         DynamicTestCase(SphereGeometry(), GreenExpr(), 0, fmm_backend="fmmlib"),
         DynamicTestCase(SphereGeometry(), GreenExpr(), 1.2, fmm_backend="fmmlib")
 ])
-def test_identity_convergence(ctx_factory,  case, visualize=False):
+def test_identity_convergence(actx_factory,  case, visualize=False):
     logging.basicConfig(level=logging.INFO)
 
     case.check()
 
-    cl_ctx = ctx_factory()
-    queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = actx_factory()
 
     # prevent cache 'splosion
     from sympy.core.cache import clear_cache

--- a/test/test_linalg_utils.py
+++ b/test/test_linalg_utils.py
@@ -20,27 +20,27 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import pytest
+
 import numpy as np
 import numpy.linalg as la
 
-import pyopencl as cl
-from arraycontext import PyOpenCLArrayContext
-
-import pytest
-from pyopencl.tools import (  # noqa
-        pytest_generate_tests_for_pyopencl
-        as pytest_generate_tests)
+from meshmode import _acf           # noqa: F401
+from arraycontext import pytest_generate_tests_for_array_contexts
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 
 import logging
 logger = logging.getLogger(__name__)
 
+pytest_generate_tests = pytest_generate_tests_for_array_contexts([
+    PytestPyOpenCLArrayContextFactory,
+    ])
+
 
 # {{{ test_matrix_block_index
 
-def test_matrix_block_index(ctx_factory):
-    ctx = ctx_factory()
-    queue = cl.CommandQueue(ctx)
-    actx = PyOpenCLArrayContext(queue)
+def test_matrix_block_index(actx_factory):
+    actx = actx_factory()
 
     # {{{ setup
 

--- a/test/test_maxwell.py
+++ b/test/test_maxwell.py
@@ -335,7 +335,9 @@ def test_pec_mfie_extinction(actx_factory, case,
 
         # {{{ system solve
 
-        h_max = bind(places, sym.h_max(qbx.ambient_dim))(actx)
+        h_max = actx.to_numpy(
+                bind(places, sym.h_max(qbx.ambient_dim))(actx)
+                )
 
         pde_test_inc = EHField(vector_from_device(actx.queue,
             eval_inc_field_at(places, target="patch_target")))
@@ -397,12 +399,15 @@ def test_pec_mfie_extinction(actx_factory, case,
             eval_repr_at(places, target="patch_target")))
 
         maxwell_residuals = [
-                calc_patch.norm(x, np.inf) / calc_patch.norm(pde_test_repr.e, np.inf)
+                actx.to_numpy(
+                    calc_patch.norm(x, np.inf)
+                    / calc_patch.norm(pde_test_repr.e, np.inf))
                 for x in frequency_domain_maxwell(
                     calc_patch, pde_test_repr.e, pde_test_repr.h, case.k)]
         print("Maxwell residuals:", maxwell_residuals)
 
-        eoc_rec_repr_maxwell.add_data_point(h_max, max(maxwell_residuals))
+        eoc_rec_repr_maxwell.add_data_point(
+                actx.to_numpy(h_max), max(maxwell_residuals))
 
         # }}}
 
@@ -420,8 +425,12 @@ def test_pec_mfie_extinction(actx_factory, case,
         def scat_norm(f):
             return norm(density_discr, f, p=np.inf)
 
-        e_bc_residual = scat_norm(eh_bc_values[:3]) / scat_norm(inc_field_scat.e)
-        h_bc_residual = scat_norm(eh_bc_values[3]) / scat_norm(inc_field_scat.h)
+        e_bc_residual = actx.to_numpy(
+                scat_norm(eh_bc_values[:3]) / scat_norm(inc_field_scat.e)
+                )
+        h_bc_residual = actx.to_numpy(
+                scat_norm(eh_bc_values[3]) / scat_norm(inc_field_scat.h)
+                )
 
         print("E/H PEC BC residuals:", h_max, e_bc_residual, h_bc_residual)
 
@@ -485,9 +494,11 @@ def test_pec_mfie_extinction(actx_factory, case,
         def obs_norm(f):
             return norm(obs_discr, f, p=np.inf)
 
-        rel_err_e = (obs_norm(inc_field_obs.e + obs_repr.e)
+        rel_err_e = actx.to_numpy(
+                obs_norm(inc_field_obs.e + obs_repr.e)
                 / obs_norm(inc_field_obs.e))
-        rel_err_h = (obs_norm(inc_field_obs.h + obs_repr.h)
+        rel_err_h = actx.to_numpy(
+                obs_norm(inc_field_obs.h + obs_repr.h)
                 / obs_norm(inc_field_obs.h))
 
         # }}}

--- a/test/test_muller.py
+++ b/test/test_muller.py
@@ -20,8 +20,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-import numpy as np
 import pytest
+
+import numpy as np
 
 
 @pytest.mark.parametrize("true_roots", [

--- a/test/test_scalar_int_eq.py
+++ b/test/test_scalar_int_eq.py
@@ -20,12 +20,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import pytest
+
 import numpy as np
 import numpy.linalg as la
-import pyopencl as cl
-import pyopencl.clmath  # noqa
 
-from arraycontext import PyOpenCLArrayContext
 from meshmode.discretization.visualization import make_visualizer
 from meshmode.dof_array import flatten_to_numpy
 
@@ -35,19 +34,22 @@ from pytential import bind, sym
 from pytential import GeometryCollection
 from pytools.obj_array import flat_obj_array
 
+from meshmode import _acf           # noqa: F401
+from arraycontext import pytest_generate_tests_for_array_contexts
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+
 import extra_int_eq_data as inteq
-
-import pytest
-from pyopencl.tools import (  # noqa
-        pytest_generate_tests_for_pyopencl as pytest_generate_tests)
-
 import logging
 logger = logging.getLogger(__name__)
+
+pytest_generate_tests = pytest_generate_tests_for_array_contexts([
+    PytestPyOpenCLArrayContextFactory,
+    ])
 
 
 # {{{ test backend
 
-def run_int_eq_test(actx: PyOpenCLArrayContext,
+def run_int_eq_test(actx,
         case, resolution, visualize=False, check_spectrum=False):
     refiner_extra_kwargs = {}
     if case.use_refinement:
@@ -466,12 +468,10 @@ cases += [
 # 'test_integral_equation(cl._csc, EllipseIntEqTestCase(LaplaceKernel, "dirichlet", +1), visualize=True)'  # noqa: E501
 
 @pytest.mark.parametrize("case", cases)
-def test_integral_equation(ctx_factory, case, visualize=False):
+def test_integral_equation(actx_factory, case, visualize=False):
     logging.basicConfig(level=logging.INFO)
 
-    cl_ctx = ctx_factory()
-    queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = actx_factory()
 
     # prevent cache 'splosion
     from sympy.core.cache import clear_cache

--- a/test/test_scalar_int_eq.py
+++ b/test/test_scalar_int_eq.py
@@ -431,7 +431,7 @@ def run_int_eq_test(actx,
 
     h_max = bind(places, sym.h_max(ambient_dim))(actx)
     return dict(
-            h_max=h_max,
+            h_max=actx.to_numpy(h_max),
             rel_err_2=rel_err_2,
             rel_err_inf=rel_err_inf,
             rel_td_err_inf=rel_td_err_inf,

--- a/test/test_stokes.py
+++ b/test/test_stokes.py
@@ -160,7 +160,7 @@ def run_exterior_stokes(actx_factory, *,
 
     if ambient_dim == 2:
         total_charge = make_obj_array([
-            actx.np.sum(c) for c in charges
+            actx.to_numpy(actx.np.sum(c)) for c in charges
             ])
         omega = bind(places, total_charge * sym.Ones())(actx)
 
@@ -204,7 +204,7 @@ def run_exterior_stokes(actx_factory, *,
             y_norm = 1.0
 
         d = x - y
-        return actx.np.linalg.norm(d.dot(d), ord=2) / y_norm
+        return actx.to_numpy(actx.np.linalg.norm(d.dot(d), ord=2) / y_norm)
 
     ps_velocity = bind(places, sym_velocity,
             auto_where=("source", "point_target"))(actx, sigma=sigma, **op_context)
@@ -212,7 +212,9 @@ def run_exterior_stokes(actx_factory, *,
             auto_where=("point_source", "point_target"))(actx, sigma=charges, mu=mu)
 
     v_error = rnorm2(ps_velocity, ex_velocity)
-    h_max = bind(places, sym.h_max(ambient_dim))(actx)
+    h_max = actx.to_numpy(
+            bind(places, sym.h_max(ambient_dim))(actx)
+            )
 
     logger.info("resolution %4d h_max %.5e error %.5e",
             resolution, h_max, v_error)

--- a/test/test_symbolic.py
+++ b/test/test_symbolic.py
@@ -21,39 +21,40 @@ THE SOFTWARE.
 """
 
 import pytest
+from functools import partial
 
 import numpy as np
 import numpy.linalg as la
 
 import pyopencl as cl
-import pyopencl.array  # noqa
-import pyopencl.clmath  # noqa
+import pyopencl.array
+import pyopencl.clmath
 
+from arraycontext import thaw
+import meshmode.mesh.generation as mgen
+from meshmode.discretization import Discretization
+from meshmode.discretization.poly_element import \
+    InterpolatoryQuadratureSimplexGroupFactory
 from pytential import bind, sym
+
+from meshmode import _acf           # noqa: F401
+from arraycontext import pytest_generate_tests_for_array_contexts
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 
 import logging
 logger = logging.getLogger(__name__)
 
-from pyopencl.tools import (  # noqa
-        pytest_generate_tests_for_pyopencl as pytest_generate_tests)
-
-from arraycontext import PyOpenCLArrayContext, thaw
-from meshmode.mesh.generation import (  # noqa
-        ellipse, cloverleaf, starfish, drop, n_gon, qbx_peanut, WobblyCircle,
-        make_curve_mesh)
-
-from functools import partial
-from meshmode.discretization import Discretization
-from meshmode.discretization.poly_element import \
-    InterpolatoryQuadratureSimplexGroupFactory
+pytest_generate_tests = pytest_generate_tests_for_array_contexts([
+    PytestPyOpenCLArrayContextFactory,
+    ])
 
 
 # {{{ discretization getters
 
 def get_ellipse_with_ref_mean_curvature(actx, nelements, aspect=1):
     order = 4
-    mesh = make_curve_mesh(
-            partial(ellipse, aspect),
+    mesh = mgen.make_curve_mesh(
+            partial(mgen.ellipse, aspect),
             np.linspace(0, 1, nelements+1),
             order)
 
@@ -109,11 +110,9 @@ def get_torus_with_ref_mean_curvature(actx, h):
     ("torus", [8, 10, 12, 16],
         get_torus_with_ref_mean_curvature),
     ])
-def test_mean_curvature(ctx_factory, discr_name, resolutions,
+def test_mean_curvature(actx_factory, discr_name, resolutions,
         discr_and_ref_mean_curvature_getter, visualize=False):
-    ctx = ctx_factory()
-    queue = cl.CommandQueue(ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = actx_factory()
 
     from pytools.convergence import EOCRecorder
     eoc = EOCRecorder()
@@ -138,10 +137,8 @@ def test_mean_curvature(ctx_factory, discr_name, resolutions,
 
 # {{{ test_tangential_onb
 
-def test_tangential_onb(ctx_factory):
-    cl_ctx = ctx_factory()
-    queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+def test_tangential_onb(actx_factory):
+    actx = actx_factory()
 
     from meshmode.mesh.generation import generate_torus
     mesh = generate_torus(5, 2, order=3)
@@ -228,10 +225,8 @@ def test_layer_potential_construction(lpot_class, ambient_dim=2):
     ("stage2_center", sym.QBX_SOURCE_STAGE2, sym.GRANULARITY_CENTER),
     ("quad", sym.QBX_SOURCE_QUAD_STAGE2, sym.GRANULARITY_NODE)
     ])
-def test_interpolation(ctx_factory, name, source_discr_stage, target_granularity):
-    ctx = ctx_factory()
-    queue = cl.CommandQueue(ctx)
-    actx = PyOpenCLArrayContext(queue)
+def test_interpolation(actx_factory, name, source_discr_stage, target_granularity):
+    actx = actx_factory()
 
     nelements = 32
     target_order = 7
@@ -247,7 +242,7 @@ def test_interpolation(ctx_factory, name, source_discr_stage, target_granularity
             discr_stage=sym.QBX_SOURCE_QUAD_STAGE2,
             granularity=target_granularity)
 
-    mesh = make_curve_mesh(starfish,
+    mesh = mgen.make_curve_mesh(mgen.starfish,
             np.linspace(0.0, 1.0, nelements + 1),
             target_order)
     discr = Discretization(actx, mesh,
@@ -296,17 +291,15 @@ def test_interpolation(ctx_factory, name, source_discr_stage, target_granularity
 
 # {{{ test node reductions
 
-def test_node_reduction(ctx_factory):
-    ctx = ctx_factory()
-    queue = cl.CommandQueue(ctx)
-    actx = PyOpenCLArrayContext(queue)
+def test_node_reduction(actx_factory):
+    actx = actx_factory()
 
     # {{{ build discretization
 
     target_order = 4
     nelements = 32
 
-    mesh = make_curve_mesh(starfish,
+    mesh = mgen.make_curve_mesh(mgen.starfish,
             np.linspace(0.0, 1.0, nelements + 1),
             target_order)
     discr = Discretization(actx, mesh,

--- a/test/test_symbolic.py
+++ b/test/test_symbolic.py
@@ -126,7 +126,7 @@ def test_mean_curvature(actx_factory, discr_name, resolutions,
         h = 1.0 / r
         from meshmode.dof_array import flat_norm
         h_error = flat_norm(mean_curvature - ref_mean_curvature, np.inf)
-        eoc.add_data_point(h, h_error)
+        eoc.add_data_point(h, actx.to_numpy(h_error))
     print(eoc)
 
     order = min([g.order for g in discr.groups])
@@ -328,7 +328,7 @@ def test_node_reduction(actx_factory):
             (sym.NodeMin, 1),
             ]:
         r = bind(discr, func(sym.var("x")))(actx, x=ary)
-        assert abs(r - expected) < 1.0e-15, r
+        assert abs(actx.to_numpy(r) - expected) < 1.0e-15, r
 
     # }}}
 

--- a/test/test_target_specific_qbx.py
+++ b/test/test_target_specific_qbx.py
@@ -20,28 +20,24 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-
-from arraycontext import PyOpenCLArrayContext, thaw
-import numpy as np
-import numpy.linalg as la  # noqa
-import pyopencl as cl
 import pytest
-from pyopencl.tools import (  # noqa
-        pytest_generate_tests_for_pyopencl as pytest_generate_tests)
 
-from functools import partial  # noqa
-from meshmode.mesh.generation import (  # noqa
-        ellipse, cloverleaf, starfish, drop, n_gon, qbx_peanut, WobblyCircle,
-        NArmedStarfish,
-        make_curve_mesh)
+import numpy as np
 
-from pytential import bind, sym
-from pytential import GeometryCollection
-
+from arraycontext import thaw
+from pytential import GeometryCollection, bind, sym
 from sumpy.kernel import LaplaceKernel, HelmholtzKernel
+
+from meshmode import _acf           # noqa: F401
+from arraycontext import pytest_generate_tests_for_array_contexts
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 
 import logging
 logger = logging.getLogger(__name__)
+
+pytest_generate_tests = pytest_generate_tests_for_array_contexts([
+    PytestPyOpenCLArrayContextFactory,
+    ])
 
 
 def test_spherical_bessel_functions():
@@ -133,12 +129,10 @@ def test_spherical_hankel_functions():
 @pytest.mark.parametrize("op", ["S", "D", "Sp"])
 @pytest.mark.parametrize("helmholtz_k", [0, 1.2, 12 + 1.2j])
 @pytest.mark.parametrize("qbx_order", [0, 1, 5])
-def test_target_specific_qbx(ctx_factory, op, helmholtz_k, qbx_order):
+def test_target_specific_qbx(actx_factory, op, helmholtz_k, qbx_order):
     logging.basicConfig(level=logging.INFO)
 
-    cl_ctx = ctx_factory()
-    queue = cl.CommandQueue(cl_ctx)
-    actx = PyOpenCLArrayContext(queue)
+    actx = actx_factory()
 
     target_order = 4
     fmm_tol = 1e-3


### PR DESCRIPTION
This updates the tests and examples to
* use `meshmode.array_context.PyOpenCLArrayContext` instead of the one from `arraycontext`
* use the new `pytest_generate_tests_for_array_contexts` with `force_device_scalars=True`.
* use `actx_factory` instead of `ctx_factory` to get better defaults.

It's currently a draft because 
* [ ] It requires some resolution on how to broadcast device scalars with `cl.array.Array`.
* [x] Still need to go through kernels and add some tags.