### PR TITLE
Remove unneeded EvalMapperFunction

### DIFF
--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -359,35 +359,10 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
             self, actx: PyOpenCLArrayContext, insn, bound_expr, evaluate):
         raise NotImplementedError
 
-    # {{{ functions
-
-    def apply_real(self, args):
-        arg, = args
-        from pytools.obj_array import obj_array_real
-        return obj_array_real(self.rec(arg))
-
-    def apply_imag(self, args):
-        arg, = args
-        from pytools.obj_array import obj_array_imag
-        return obj_array_imag(self.rec(arg))
-
-    def apply_conj(self, args):
-        arg, = args
-        return self.rec(arg).conj()
-
-    def apply_abs(self, args):
-        arg, = args
-        return abs(self.rec(arg))
-
-    # }}}
-
     def map_call(self, expr):
-        from pytential.symbolic.primitives import (
-                EvalMapperFunction, NumpyMathFunction)
+        from pytential.symbolic.primitives import NumpyMathFunction
 
-        if isinstance(expr.function, EvalMapperFunction):
-            return getattr(self, f"apply_{expr.function.name}")(expr.parameters)
-        elif isinstance(expr.function, NumpyMathFunction):
+        if isinstance(expr.function, NumpyMathFunction):
             args = [self.rec(arg) for arg in expr.parameters]
             from numbers import Number
             if all(isinstance(arg, Number) for arg in args):

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -486,10 +486,6 @@ class Function(var):
             return var.__call__(self, operand, *args, **kwargs)
 
 
-class EvalMapperFunction(Function):
-    pass
-
-
 class NumpyMathFunction(Function):
     """A math function named within the numpy naming convention and with
     numpy-like semantics."""
@@ -506,10 +502,10 @@ class CLMathFunction(NumpyMathFunction):
         return super().__call__(*args, **kwargs)
 
 
-real = EvalMapperFunction("real")
-imag = EvalMapperFunction("imag")
-conj = EvalMapperFunction("conj")
-abs = EvalMapperFunction("abs")
+real = NumpyMathFunction("real")
+imag = NumpyMathFunction("imag")
+conj = NumpyMathFunction("conj")
+abs = NumpyMathFunction("abs")
 
 sqrt = NumpyMathFunction("sqrt")
 


### PR DESCRIPTION
This doesn't seem to be needed anymore because the array context vectorizes over object arrays already.

- [x] needs inducer/arraycontext#54
- [x] revert changes to `requirements.txt`