### PR TITLE
Allow subclasses of QBXLayerPotentialSource in copy

### DIFF
--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -281,7 +281,7 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
 
         # FIXME Could/should share wrangler and geometry kernels
         # if no relevant changes have been made.
-        return QBXLayerPotentialSource(
+        return type(self)(
                 density_discr=density_discr or self.density_discr,
                 fine_order=(
                     fine_order if fine_order is not None else self.fine_order),


### PR DESCRIPTION
I added some custom primitives to my code and had to subclass the various mappers to support them. 

For this PR, had to subclass `QBXLayerPotentialSource` to use a custom `QBXPreprocessor` in `preprocess_optemplate` (it just has a different `IdentityMapper` as a base).

There are a couple of places that also used some mappers with no easy way to replace them:
* `BoundExpression` uses the `EvaluationMapper` class in `eval`.
* `OperatorCompiler` uses the `OperatorCollector` in `__call__`.
* `OperatorCompiler` and `Code` use the `DependencyMapper` in a couple of places.

This `copy` was a bit too complex to copy paste, but the rest of them are not, so I'm not sure to what extent it's worth adding more arguments / attributes to make that easier.