### PR TITLE
Remove a bunch of deprecated functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
                 grep -v symengine .test-conda-env-py3.yml > .test-conda-env.yml
                 CONDA_ENVIRONMENT=.test-conda-env.yml
 
-                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:--k-slowtest}
+                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-k 'not slowtest'"}
 
                 curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project-within-miniconda.sh
                 . ./build-and-test-py-project-within-miniconda.sh
@@ -88,7 +88,7 @@ jobs:
                 echo "- compilers" >> .test-conda-env.yml
                 echo "- llvm-openmp" >> .test-conda-env.yml
                 CONDA_ENVIRONMENT=.test-conda-env.yml
-                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:--k-slowtest}
+                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-k 'not slowtest'"}
 
                 curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project-within-miniconda.sh
                 . ./build-and-test-py-project-within-miniconda.sh
@@ -102,7 +102,7 @@ jobs:
             run: |
                 CONDA_ENVIRONMENT=.test-conda-env-py3.yml
 
-                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:--k-slowtest}
+                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-k 'not slowtest'"}
 
                 curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project-within-miniconda.sh
                 . ./build-and-test-py-project-within-miniconda.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,6 @@
 # Environment variables
 #
-# * PYTEST_ADDOPTS is used to filter test runs. The default value is "-k-slowtest",
+# * PYTEST_ADDOPTS is used to filter test runs. The default value is "-k 'not slowtest'",
 #   which skips the slow running tests.
 # * SKIP_EXAMPLES, if non-empty, can be used to skip the examples job.
 
@@ -8,7 +8,7 @@ Python 3 POCL:
   script:
   - export PY_EXE=python3
   - export PYOPENCL_TEST=portable:pthread
-  - export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:--k-slowtest}
+  - export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-k 'not slowtest'"}
   - export EXTRA_INSTALL="Cython pybind11 numpy scipy mako"
   - curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project.sh
   - ". ./build-and-test-py-project.sh"
@@ -27,7 +27,7 @@ Python 3 Intel:
   - export PY_EXE=python3
   - source /opt/enable-intel-cl.sh
   - export PYOPENCL_TEST="intel(r):pu"
-  - export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:--k-slowtest}
+  - export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-k 'not slowtest'"}
   - export EXTRA_INSTALL="Cython pybind11 numpy scipy mako"
   - curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project.sh
   - ". ./build-and-test-py-project.sh"
@@ -60,7 +60,7 @@ Python 3 Conda:
   script:
   - export SUMPY_FORCE_SYMBOLIC_BACKEND=symengine
   - export CONDA_ENVIRONMENT=.test-conda-env-py3.yml
-  - export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:--k-slowtest}
+  - export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-k 'not slowtest'"}
 
   - curl -L -O -k https://gitlab.tiker.net/inducer/ci-support/raw/main/build-and-test-py-project-within-miniconda.sh
   - ". ./build-and-test-py-project-within-miniconda.sh"

--- a/experiments/maxwell_sphere.py
+++ b/experiments/maxwell_sphere.py
@@ -27,16 +27,7 @@ def main():
     # cl.array.to_device(queue, numpy_array)
     from meshmode.mesh.io import generate_gmsh, FileSource
     from meshmode.mesh.generation import generate_sphere
-    from meshmode.mesh.refinement import Refiner
-    mesh = generate_sphere(1,target_order)
-
-    refinement_increment = 1
-    refiner = Refiner(mesh)
-    for i in range(refinement_increment):
-        flags = np.ones(mesh.nelements, dtype=bool)
-        refiner.refine(flags)
-        mesh = refiner.get_current_mesh()
-
+    mesh = generate_sphere(1, target_order, uniform_refinement_rounds=1)
 
     from meshmode.mesh.processing import perform_flips
     # Flip elements--gmsh generates inside-out geometry.

--- a/experiments/maxwell_sphere.py
+++ b/experiments/maxwell_sphere.py
@@ -26,9 +26,9 @@ k = 4
 def main():
     # cl.array.to_device(queue, numpy_array)
     from meshmode.mesh.io import generate_gmsh, FileSource
-    from meshmode.mesh.generation import generate_icosphere
+    from meshmode.mesh.generation import generate_sphere
     from meshmode.mesh.refinement import Refiner
-    mesh = generate_icosphere(1,target_order)
+    mesh = generate_sphere(1,target_order)
 
     refinement_increment = 1
     refiner = Refiner(mesh)
@@ -135,7 +135,7 @@ def main():
         # magnetic field corresponding to dyadic green's function
         # due to monochromatic electric dipole located at "source".
         # "strength" is the the intensity of the dipole.
-        #  H = curl((I + Hess)(exp(ikr)/r) dot (strength)) = 
+        #  H = curl((I + Hess)(exp(ikr)/r) dot (strength)) =
         #  strength \cross \grad (exp(ikr)/r)
         #
             dx = x - source[0]
@@ -165,7 +165,7 @@ def main():
 #            print(hvec)
 #            print(strength)
             return evec,hvec
-            
+
         def dipole3m(x,y,z,source,strength,k):
         #
         #  evalaute electric and magnetic field due
@@ -175,7 +175,7 @@ def main():
             hvec = green3e(x,y,z,source,strength,k)
             hvec = -hvec*1j*k
             return evec,hvec
-            
+
 
         def dipole3eall(x,y,z,sources,strengths,k):
             ns = len(strengths)
@@ -194,7 +194,7 @@ def main():
 #        source[1] =-0.03
 #        source[2] = 0.02
         strength = np.ones(3)
-       
+
 #        evec = cl.array.to_device(queue,np.zeros((3,len(nodes[0])),dtype=np.complex128))
 #        hvec = cl.array.to_device(queue,np.zeros((3,len(nodes[0])),dtype=np.complex128))
 

--- a/pytential/linalg/proxy.py
+++ b/pytential/linalg/proxy.py
@@ -451,8 +451,7 @@ def make_compute_block_qbx_radii_knl(
                 <> rqbx_int = simul_reduce(max, i, sqrt(simul_reduce(sum, idim, \
                         (proxy_centers[idim, irange] -
                          center_int[idim, srcindices[i + ioffset]]) ** 2)) + \
-                         expansion_radii[srcindices[i + ioffset]]) \
-                         {dup=idim}
+                         expansion_radii[srcindices[i + ioffset]])
                 <> rqbx_ext = simul_reduce(max, i, sqrt(simul_reduce(sum, idim, \
                         (proxy_centers[idim, irange] -
                          center_ext[idim, srcindices[i + ioffset]]) ** 2)) + \

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -1011,9 +1011,6 @@ class BoundExpression:
         """
         array_context = _find_array_context_from_args_in_context(kwargs)
 
-        if array_context is None:
-            raise ValueError("unable to figure array context from arguments")
-
         cost_model_mapper = CostModelMapper(
             self, array_context, calibration_params, per_box=False, context=kwargs
         )

--- a/pytential/symbolic/matrix.py
+++ b/pytential/symbolic/matrix.py
@@ -346,10 +346,14 @@ class MatrixBuilder(MatrixBuilderBase):
             except KeyError:
                 from meshmode.discretization.connection import \
                     flatten_chained_connection
+                from meshmode.discretization.connection.direct import \
+                    make_direct_full_resample_matrix
 
                 conn = self.places.get_connection(expr.from_dd, expr.to_dd)
                 conn = flatten_chained_connection(actx, conn)
-                mat = actx.to_numpy(conn.full_resample_matrix(actx))
+                mat = actx.to_numpy(
+                    make_direct_full_resample_matrix(actx, conn)
+                    )
 
                 # FIXME: the resample matrix is slow to compute and very big
                 # to store, so caching it may not be the best idea

--- a/test/extra_int_eq_data.py
+++ b/test/extra_int_eq_data.py
@@ -362,8 +362,8 @@ class SphereTestCase(IntegralEquationTestCase):
     check_tangential_deriv = False
 
     def get_mesh(self, resolution, mesh_order):
-        from meshmode.mesh.generation import generate_icosphere
-        return generate_icosphere(1.0, mesh_order,
+        from meshmode.mesh.generation import generate_sphere
+        return generate_sphere(1.0, mesh_order,
                 uniform_refinement_rounds=resolution)
 
 

--- a/test/test_cost_model.py
+++ b/test/test_cost_model.py
@@ -347,7 +347,7 @@ def test_timing_data_gathering(ctx_factory):
     pytest.importorskip("pyfmmlib")
 
     import pyopencl as cl
-    from arraycontext import PyOpenCLArrayContext
+    from meshmode.array_context import PyOpenCLArrayContext
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx,
             properties=cl.command_queue_properties.PROFILING_ENABLE)

--- a/test/test_global_qbx.py
+++ b/test/test_global_qbx.py
@@ -235,7 +235,7 @@ def test_source_refinement_2d(actx_factory, curve_name, curve_f, nelements):
 
 
 @pytest.mark.parametrize(("surface_name", "surface_f", "order"), [
-    ("sphere", partial(mgen.generate_icosphere, 1), 4),
+    ("sphere", partial(mgen.generate_sphere, 1), 4),
     ("torus", partial(mgen.generate_torus, 3, 1, n_minor=10, n_major=7), 6),
     ])
 def test_source_refinement_3d(actx_factory, surface_name, surface_f, order):

--- a/test/test_layer_pot_eigenvalues.py
+++ b/test/test_layer_pot_eigenvalues.py
@@ -280,14 +280,8 @@ def test_sphere_eigenvalues(actx_factory, mode_m, mode_n, qbx_order,
 
     for nrefinements in [0, 1]:
         from meshmode.mesh.generation import generate_sphere
-        mesh = generate_sphere(1, target_order)
-        from meshmode.mesh.refinement import Refiner
-
-        refiner = Refiner(mesh)
-        for _ in range(nrefinements):
-            flags = np.ones(mesh.nelements, dtype=bool)
-            refiner.refine(flags)
-            mesh = refiner.get_current_mesh()
+        mesh = generate_sphere(1, target_order,
+                uniform_refinement_rounds=nrefinements)
 
         pre_density_discr = Discretization(
                 actx, mesh,

--- a/test/test_layer_pot_eigenvalues.py
+++ b/test/test_layer_pot_eigenvalues.py
@@ -279,8 +279,8 @@ def test_sphere_eigenvalues(actx_factory, mode_m, mode_n, qbx_order,
                 )
 
     for nrefinements in [0, 1]:
-        from meshmode.mesh.generation import generate_icosphere
-        mesh = generate_icosphere(1, target_order)
+        from meshmode.mesh.generation import generate_sphere
+        mesh = generate_sphere(1, target_order)
         from meshmode.mesh.refinement import Refiner
 
         refiner = Refiner(mesh)

--- a/test/test_layer_pot_identity.py
+++ b/test/test_layer_pot_identity.py
@@ -54,8 +54,8 @@ d2 = sym.Derivative()
 
 
 def get_sphere_mesh(refinement_increment, target_order):
-    from meshmode.mesh.generation import generate_icosphere
-    mesh = generate_icosphere(1, target_order)
+    from meshmode.mesh.generation import generate_sphere
+    mesh = generate_sphere(1, target_order)
     from meshmode.mesh.refinement import Refiner
 
     refiner = Refiner(mesh)

--- a/test/test_layer_pot_identity.py
+++ b/test/test_layer_pot_identity.py
@@ -55,16 +55,8 @@ d2 = sym.Derivative()
 
 def get_sphere_mesh(refinement_increment, target_order):
     from meshmode.mesh.generation import generate_sphere
-    mesh = generate_sphere(1, target_order)
-    from meshmode.mesh.refinement import Refiner
-
-    refiner = Refiner(mesh)
-    for _ in range(refinement_increment):
-        flags = np.ones(mesh.nelements, dtype=bool)
-        refiner.refine(flags)
-        mesh = refiner.get_current_mesh()
-
-    return mesh
+    return generate_sphere(1, target_order,
+            uniform_refinement_rounds=refinement_increment)
 
 
 class StarfishGeometry:

--- a/test/test_linalg_proxy.py
+++ b/test/test_linalg_proxy.py
@@ -152,8 +152,8 @@ def plot_proxy_geometry(
             from meshmode.discretization.poly_element import \
                 InterpolatoryQuadratureSimplexGroupFactory
 
-            from meshmode.mesh.generation import generate_icosphere
-            ref_mesh = generate_icosphere(1, 4, uniform_refinement_rounds=1)
+            from meshmode.mesh.generation import generate_sphere
+            ref_mesh = generate_sphere(1, 4, uniform_refinement_rounds=1)
             pxycenters = np.stack(pxy.centers)
 
             for i in range(indices.nblocks):

--- a/test/test_maxwell.py
+++ b/test/test_maxwell.py
@@ -65,19 +65,17 @@ class SphereTestCase(MaxwellTestCase):
     gmres_tol = 1e-10
 
     def get_mesh(self, resolution, target_order):
-        from meshmode.mesh.generation import generate_icosphere
-        from meshmode.mesh.refinement import refine_uniformly
-        return refine_uniformly(
-                generate_icosphere(2, target_order),
-                resolution)
+        from meshmode.mesh.generation import generate_sphere
+        return generate_sphere(2, target_order,
+                uniform_refinement_rounds=resolution)
 
     def get_observation_mesh(self, target_order):
-        from meshmode.mesh.generation import generate_icosphere
+        from meshmode.mesh.generation import generate_sphere
 
         if self.is_interior:
-            return generate_icosphere(5, target_order)
+            return generate_sphere(5, target_order)
         else:
-            return generate_icosphere(0.5, target_order)
+            return generate_sphere(0.5, target_order)
 
     def get_source(self, actx):
         if self.is_interior:
@@ -114,12 +112,12 @@ class RoundedCubeTestCase(MaxwellTestCase):
         return perform_flips(mesh, np.ones(mesh.nelements))
 
     def get_observation_mesh(self, target_order):
-        from meshmode.mesh.generation import generate_icosphere
+        from meshmode.mesh.generation import generate_sphere
 
         if self.is_interior:
-            return generate_icosphere(5, target_order)
+            return generate_sphere(5, target_order)
         else:
-            return generate_icosphere(0.5, target_order)
+            return generate_sphere(0.5, target_order)
 
     def get_source(self, actx):
         if self.is_interior:
@@ -159,12 +157,12 @@ class ElliptiPlaneTestCase(MaxwellTestCase):
         return perform_flips(mesh, np.ones(mesh.nelements))
 
     def get_observation_mesh(self, target_order):
-        from meshmode.mesh.generation import generate_icosphere
+        from meshmode.mesh.generation import generate_sphere
 
         if self.is_interior:
-            return generate_icosphere(12, target_order)
+            return generate_sphere(12, target_order)
         else:
-            return generate_icosphere(0.5, target_order)
+            return generate_sphere(0.5, target_order)
 
     def get_source(self, actx):
         if self.is_interior:

--- a/test/test_stokes.py
+++ b/test/test_stokes.py
@@ -70,8 +70,8 @@ def run_exterior_stokes(actx_factory, *,
                 np.linspace(0.0, 1.0, resolution + 1),
                 target_order)
     elif ambient_dim == 3:
-        from meshmode.mesh.generation import generate_icosphere
-        mesh = generate_icosphere(radius, target_order + 1,
+        from meshmode.mesh.generation import generate_sphere
+        mesh = generate_sphere(radius, target_order + 1,
                 uniform_refinement_rounds=resolution)
     else:
         raise ValueError(f"unsupported dimension: {ambient_dim}")

--- a/test/test_target_specific_qbx.py
+++ b/test/test_target_specific_qbx.py
@@ -137,8 +137,8 @@ def test_target_specific_qbx(actx_factory, op, helmholtz_k, qbx_order):
     target_order = 4
     fmm_tol = 1e-3
 
-    from meshmode.mesh.generation import generate_icosphere
-    mesh = generate_icosphere(1, target_order)
+    from meshmode.mesh.generation import generate_sphere
+    mesh = generate_sphere(1, target_order)
 
     from meshmode.discretization import Discretization
     from meshmode.discretization.poly_element import \


### PR DESCRIPTION
The commits should be fairly self-contained, i.e. each removes one deprecated function. 
Together with inducer/sumpy#81, this should hopefully get rid of a good chunk of the deprecation warnings.