### PR TITLE
Add some Laplace-Beltrami-type operators

### DIFF
--- a/doc/symbolic.rst
+++ b/doc/symbolic.rst
@@ -35,6 +35,11 @@ Stokes' equations
 
 .. automodule:: pytential.symbolic.stokes
 
+Scalar Beltrami equations
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: pytential.symbolic.pde.beltrami
+
 Internal affairs
 ----------------
 

--- a/pytential/symbolic/pde/beltrami.py
+++ b/pytential/symbolic/pde/beltrami.py
@@ -190,7 +190,7 @@ class BeltramiOperator:
         context.update(kwargs)
 
         knl = self.kernel
-        lknl = LaplaceKernel(self.dim)
+        lknl = LaplaceKernel(knl.dim)
 
         # {{{ layer potentials
 
@@ -235,7 +235,6 @@ class BeltramiOperator:
             mean_curvature = sym.mean_curvature(self.ambient_dim, dim=self.dim)
 
         kappa = self.dim * mean_curvature
-
         if self.precond == "left":
             return self._get_left_operator(sigma, kappa, **kwargs)
         else:

--- a/pytential/symbolic/pde/beltrami.py
+++ b/pytential/symbolic/pde/beltrami.py
@@ -91,6 +91,7 @@ class BeltramiOperator:
 
         context = self.kernel_arguments.copy()
         context.update(kwargs)
+        kappa = (self.dim - 1) * kappa
 
         knl = self.kernel
         lknl = LaplaceKernel(self.dim)
@@ -155,6 +156,7 @@ class LaplaceBeltramiOperator(BeltramiOperator):
         knl = self.kernel
         context = self.kernel_arguments.copy()
         context.update(kwargs)
+        kappa = (self.dim - 1) * kappa
 
         # {{{ layer potentials
 
@@ -177,7 +179,7 @@ class LaplaceBeltramiOperator(BeltramiOperator):
                 - D(D(sigma))
                 + S(Spp(sigma) + Dp(sigma))
                 + S(kappa * Sp(sigma))
-                + S(W(S(sigma)))
+                - S(W(S(sigma)))
                 )
 
         # }}}
@@ -188,6 +190,7 @@ class LaplaceBeltramiOperator(BeltramiOperator):
         knl = self.kernel
         context = self.kernel_arguments.copy()
         context.update(kwargs)
+        kappa = (self.dim - 1) * kappa
 
         # {{{ layer potentials
 

--- a/pytential/symbolic/pde/beltrami.py
+++ b/pytential/symbolic/pde/beltrami.py
@@ -1,0 +1,242 @@
+__copyright__ = "Copyright (C) 2021 Alexandru Fikl"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+__doc__ = """
+.. autoclass:: LaplaceBeltramiOperator
+.. autoclass:: YukawaBeltramiOperator
+.. autoclass:: HelmholtzbeltramiOperator
+"""
+
+from functools import partial
+from typing import Any, Dict, Optional
+
+from pytential import sym
+from sumpy.kernel import Kernel
+
+
+# {{{ beltrami operator
+
+class BeltramiOperator:
+    def __init__(self, kernel: Kernel, *,
+            precond: str = "left",
+            kernel_arguments: Optional[Dict[str, Any]]) -> None:
+        if kernel_arguments is None:
+            kernel_arguments = {}
+
+        if precond not in ("left", "right"):
+            raise ValueError(f"unknown preconditioning '{precond}'")
+
+        self.kernel = kernel
+        self.precond = precond
+
+    @property
+    def dim(self):
+        return self.kernel.dim
+
+    def get_density_var(self, name: str = "sigma"):
+        return sym.var(name)
+
+    def prepare_solution(self, sigma: sym.var) -> sym.var:
+        S = partial(sym.S, self.kernel,     # noqa: N806
+                qbx_forced_limit=+1, **self.kernel_arguments)
+
+        if self.precond == "left":
+            return S(sigma)
+        else:
+            return S(S(sigma))
+
+    def prepare_rhs(self, b: sym.var) -> sym.var:
+        S = partial(sym.S, self.kernel,     # noqa: N806
+                qbx_forced_limit=+1, **self.kernel_arguments)
+
+        if self.precond == "left":
+            return S(b)
+        else:
+            return b
+
+    def _get_left_operator(self, sigma: sym.var, kappa: sym.var, **kwargs: Any):
+        from sumpy.kernel import LaplaceKernel
+        if isinstance(self.kernel, LaplaceKernel):
+            raise TypeError(
+                    f"{type(self).__name__} does not support the Laplace "
+                    "kernel, use LaplaceBeltramiOperator instead")
+
+        context = self.kernel_arguments.copy()
+        context.update(kwargs)
+
+        knl = self.kernel
+        lknl = LaplaceKernel(self.dim)
+
+        # {{{ layer potentials
+
+        # laplace
+        S0 = partial(sym.S, lknl, qbx_forced_limit=+1, **kwargs)        # noqa: N806
+        D0 = partial(sym.D, lknl, qbx_forced_limit="avg", **kwargs)     # noqa: N806
+        Dp0 = partial(sym.Dp, lknl, qbx_forced_limit="avg", **kwargs)   # noqa: N806
+
+        # base
+        S = partial(sym.S, knl, qbx_forced_limit=+1, **context)         # noqa: N806
+        Sp = partial(sym.Sp, knl, qbx_forced_limit="avg", **context)    # noqa: N806
+        Spp = partial(sym.Spp, knl, qbx_forced_limit="avg", **context)  # noqa: N806
+
+        # }}}
+
+        # {{{ operator
+
+        # similar to 6.2 in [ONeil2017]
+        op = (
+                sigma / 4
+                - D0(D0(sigma))
+                + S(kappa * Sp(sigma))
+                + S(Spp(sigma) + Dp0(sigma))
+                - S(Dp0(sigma))
+                + S0(Dp0(sigma))
+                )
+
+        # }}}
+
+        return op
+
+    def _get_right_operator(self, sigma, **kwargs):
+        raise NotImplementedError(
+                f"right preconditioning for {type(self.kernel).__name__}")
+
+    def operator(self,
+            sigma: sym.var,
+            mean_curvature: Optional[sym.var] = None,
+            **kwargs) -> sym.var:
+        if mean_curvature is None:
+            mean_curvature = sym.mean_curvature(self.dim)
+
+        if self.precond == "left":
+            return self._get_left_operator(self, sigma, mean_curvature, **kwargs)
+        else:
+            return self._get_right_operator(self, sigma, mean_curvature, **kwargs)
+
+# }}}
+
+
+# {{{ Laplace-Beltrami operator
+
+class LaplaceBeltramiOperator(BeltramiOperator):
+    def __init__(self, dim: int, precond: str = "left") -> None:
+        from sumpy.kernel import LaplaceKernel
+        super().__init__(kernel=LaplaceKernel(dim), precond=precond)
+
+    def _get_left_operator(self, sigma: sym.var, kappa: sym.var, **kwargs: Any):
+        knl = self.kernel
+        context = self.kernel_arguments.copy()
+        context.update(kwargs)
+
+        # {{{ layer potentials
+
+        S = partial(sym.S, knl, qbx_forced_limit=+1, **context)          # noqa: N806
+        Sp = partial(sym.Sp, knl, qbx_forced_limit="avg", **context)     # noqa: N806
+        Spp = partial(sym.Spp, knl, qbx_forced_limit="avg", **context)   # noqa: N806
+        D = partial(sym.D, knl, qbx_forced_limit="avg", **context)       # noqa: N806
+        Dp = partial(sym.Dp, knl, qbx_forced_limit="avg", **context)     # noqa: N806
+
+        # }}}
+
+        # {{{ operator
+
+        def W(operand: sym.Expression) -> sym.Expression:                # noqa: N802
+            return sym.Ones() * sym.integral(self.ambient_dim, self.dim, operand)
+
+        # NOTE: based on Lemma 3.1 in [ONeil2017], but doing :math:`-\Delta_\Gamma`
+        op = (
+                sigma / 4
+                - D(D(sigma))
+                + S(Spp(sigma) + Dp(sigma))
+                + S(kappa * Sp(sigma))
+                + S(W(S(sigma)))
+                )
+
+        # }}}
+
+        return op
+
+    def _get_right_operator(self, sigma: sym.var, kappa: sym.var, **kwargs: Any):
+        knl = self.kernel
+        context = self.kernel_arguments.copy()
+        context.update(kwargs)
+
+        # {{{ layer potentials
+
+        S = partial(sym.S, knl, qbx_forced_limit=+1, **context)          # noqa: N806
+        Sp = partial(sym.Sp, knl, qbx_forced_limit="avg", **context)     # noqa: N806
+        Spp = partial(sym.Spp, knl, qbx_forced_limit="avg", **context)   # noqa: N806
+        Dp = partial(sym.Dp, knl, qbx_forced_limit="avg", **context)     # noqa: N806
+
+        # }}}
+
+        # {{{ operator
+
+        def W(operand: sym.Expression) -> sym.Expression:                # noqa: N802
+            return sym.Ones() * sym.integral(self.ambient_dim, self.dim, operand)
+
+        # NOTE: based on Lemma 3.2 in [ONeil2017], but doing :math:`-\Delta_\Gamma`
+        op = (
+                sigma / 4
+                - Sp(Sp(sigma))
+                + (Spp(S(sigma)) + Dp(S(sigma)))
+                + kappa * Sp(S(sigma))
+                + W(S(S(sigma)))
+                )
+
+        # }}}
+
+        return op
+
+# }}}
+
+
+# {{{ Yukawa-Beltrami operator
+
+class YukawaBeltramiOperator(BeltramiOperator):
+    def __init__(self, dim: int,
+            precond: str = "left",
+            yukawa_k_name: str = "k") -> None:
+        from sumpy.kernel import YukawaKernel
+        super().__init__(
+                kernel=YukawaKernel(dim, yukawa_lambda_name=yukawa_k_name),
+                precond=precond,
+                kernel_arguments={yukawa_k_name: sym.var(yukawa_k_name)}
+                )
+
+# }}}
+
+
+# {{{ Helmholtz-Beltrami operator
+
+class HelmholtzBeltramiOperator(BeltramiOperator):
+    def __init__(self, dim: int,
+            precond: str = "left",
+            helmholtz_k_name: str = "k") -> None:
+        from sumpy.kernel import HelmholtzKernel
+        super().__init__(
+                kernel=HelmholtzKernel(dim, yukawa_lambda_name=helmholtz_k_name),
+                precond=precond,
+                kernel_arguments={helmholtz_k_name: sym.var(helmholtz_k_name)}
+                )
+
+# }}}

--- a/test/test_beltrami.py
+++ b/test/test_beltrami.py
@@ -128,7 +128,7 @@ class LaplaceBeltramiSolution:
 @dataclass(frozen=True)
 class YukawaBeltramiSolution(LaplaceBeltramiSolution):
     name: str = "yukawa"
-    k: float = 1.0
+    k: float = 2.0
 
     @property
     def context(self):
@@ -159,7 +159,10 @@ def test_beltrami_convergence(actx_factory, operator, solution, visualize=False)
         logging.basicConfig(level=logging.INFO)
     actx = actx_factory()
 
-    radius = 1
+    from dataclasses import replace
+    radius = 1.5
+    solution = replace(solution, radius=radius)
+
     if operator.ambient_dim == 2:
         case = eid.CircleTestCase(
                 target_order=5,

--- a/test/test_beltrami.py
+++ b/test/test_beltrami.py
@@ -1,0 +1,227 @@
+__copyright__ = "Copyright (C) 2021 Alexandru Fikl"
+
+__license__ = """
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+"""
+
+from dataclasses import dataclass
+import pytest
+
+import numpy as np
+
+from meshmode import _acf           # noqa: F401
+from arraycontext import pytest_generate_tests_for_array_contexts
+from meshmode.array_context import PytestPyOpenCLArrayContextFactory
+
+from pytential import bind, sym
+from pytential.symbolic.pde.beltrami import (
+        LaplaceBeltramiOperator, YukawaBeltramiOperator)
+
+import extra_int_eq_data as eid
+import logging
+logger = logging.getLogger(__name__)
+
+pytest_generate_tests = pytest_generate_tests_for_array_contexts([
+    PytestPyOpenCLArrayContextFactory,
+    ])
+
+
+# {{{ solutions
+
+def evaluate_spharm(actx, discr, m: int, n: int) -> np.ndarray:
+    assert discr.ambient_dim == 3
+
+    # {{{ get spherical coordinates
+
+    from arraycontext import thaw
+    x, y, z = thaw(discr.nodes(), actx)
+
+    theta = actx.np.arctan2(z, actx.np.sqrt(x**2 + y**2))
+    phi = actx.np.arctan2(y, x) + np.pi * (x < 0)
+
+    # }}}
+
+    # {{{ evaluate Y^m_n
+
+    from scipy.special import sph_harm
+    y_mn = []
+    for gtheta, gphi in zip(theta, phi):
+        result = sph_harm(m, n, actx.to_numpy(gphi), actx.to_numpy(gtheta))
+
+        y_mn.append(actx.from_numpy(result))
+
+    # }}}
+
+    return type(x)(actx, tuple(y_mn))
+
+
+@dataclass(frozen=True)
+class LaplaceBeltramiSolution:
+    name: str = "laplace"
+    radius: float = 1.0
+    m: int = 1
+    n: int = 3
+
+    @property
+    def eig(self):
+        # NOTE: eigenvalue of the -Laplacian on the sphere
+        return self.n * (self.n + 1) / self.radius ** 2
+
+    @property
+    def context(self):
+        return {}
+
+    def source(self, actx, discr):
+        return self.eig * evaluate_spharm(actx, discr, self.m, self.n)
+
+    def exact(self, actx, discr):
+        return evaluate_spharm(actx, discr, self.m, self.n)
+
+
+class YukawaBeltramiSolution(LaplaceBeltramiSolution):
+    name: str = "yukawa"
+    k: float = 1.0
+
+    @property
+    def context(self):
+        return {"k": self.k}
+
+    def source(self, actx, discr):
+        return (self.eig + self.k**2) * evaluate_spharm(actx, discr, self.m, self.n)
+
+# }}}
+
+
+# {{{ test_beltrami_convergence
+
+@pytest.mark.parametrize(("operator", "solution"), [
+    (LaplaceBeltramiOperator(3, precond="left"), LaplaceBeltramiSolution()),
+    (LaplaceBeltramiOperator(3, precond="right"), LaplaceBeltramiSolution()),
+    (YukawaBeltramiOperator(3, precond="left"), YukawaBeltramiSolution()),
+    ])
+def test_beltrami_convergence(actx_factory, operator, solution, visualize=True):
+    if visualize:
+        logging.basicConfig(level=logging.INFO)
+    actx = actx_factory()
+
+    radius = 1
+    case = eid.SphereTestCase(
+            target_order=5,
+            qbx_order=5,
+            source_ovsmp=4,
+            fmm_order=False, fmm_backend=None,
+            radius=radius
+            )
+    logger.info("\n%s", case)
+
+    from pytools.convergence import EOCRecorder
+    eoc = EOCRecorder()
+
+    for resolution in case.resolutions:
+        # {{{ geometry
+
+        from pytential import GeometryCollection
+        qbx = case.get_layer_potential(actx, resolution, case.target_order)
+        places = GeometryCollection(qbx, auto_where=case.name)
+
+        density_discr = places.get_discretization(case.name)
+        logger.info("ndofs:     %d", density_discr.ndofs)
+        logger.info("nelements: %d", density_discr.mesh.nelements)
+
+        # }}}
+
+        # {{{ symbolic
+
+        sym_sigma = operator.get_density_var("sigma")
+        sym_b = operator.get_density_var("b")
+
+        sym_rhs = operator.prepare_rhs(sym_b)
+        sym_result = operator.prepare_solution(sym_sigma)
+
+        sym_op = operator.operator(sym_sigma, mean_curvature=2/radius)
+
+        # }}}
+
+        # {{{ solve
+
+        scipy_op = bind(places, sym_op).scipy_op(
+                actx, "sigma", operator.dtype, **solution.context)
+        rhs = bind(places, sym_rhs)(actx, b=solution.source(actx, density_discr))
+
+        from pytential.solve import gmres
+        result = gmres(
+                scipy_op, rhs,
+                x0=rhs,
+                tol=1.0e-10,
+                progress=visualize,
+                stall_iterations=0,
+                hard_failure=True)
+
+        result = bind(places, sym_result)(actx, sigma=result.solution)
+        ref_result = solution.exact(actx, density_discr)
+
+        # }}}
+
+        from pytential import norm
+        h_max = actx.to_numpy(
+                bind(places, sym.h_max(places.ambient_dim))(actx)
+                )
+        error = actx.to_numpy(
+                norm(density_discr, result - ref_result, p=2)
+                / norm(density_discr, ref_result, p=2)
+                )
+
+        eoc.add_data_point(h_max, error)
+        logger.info("resolution %3d h_max %.5e rel_error %.5e",
+                resolution, h_max, error)
+        print(resolution, h_max, error)
+
+        if not visualize:
+            continue
+
+        from meshmode.discretization.visualization import make_visualizer
+        vis = make_visualizer(actx, density_discr)
+
+        filename = f"beltrami_{case.name}_{solution.name}.vtu"
+        vis.write_vtk_file(filename, [
+            ("result", result),
+            ("ref_result", ref_result),
+            ("error", result - ref_result)
+            ], overwrite=True)
+
+    print(eoc.pretty_print(
+        abscissa_format="%.8e",
+        error_format="%.8e",
+        eoc_format="%.2f"))
+
+    order = min(case.target_order, case.qbx_order)
+    assert eoc.order_estimate() > order - 2.5
+
+# }}}
+
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) > 1:
+        exec(sys.argv[1])
+    else:
+        from pytest import main
+        main([__file__])
+
+# vim: fdm=marker


### PR DESCRIPTION
Adds a Laplace-Beltrami, Yukawa-Beltrami and Helmholtz-Beltrami (not sure if this is their official name?) operator based on https://arxiv.org/abs/1705.00069.

There was some version of the Laplace-Beltrami one in `pytential/symbolic/old_diffop_primitives.py`, but this is hopefully cleaner and the interface is in line with the other scalar operators.