### PR TITLE
Fix _small_mat primitive helpers

### DIFF
--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -830,13 +830,13 @@ def _small_mat_inverse(mat):
         raise ValueError("inverses only make sense for square matrices")
 
     if m == 1:
-        return make_obj_array([1/mat[0, 0]])
+        return np.array([[1/mat[0, 0]]], dtype=object)
     elif m == 2:
         (a, b), (c, d) = mat
-        return 1/(a*d-b*c) * make_obj_array([
+        return 1/(a*d - b*c) * np.array([
             [d, -b],
             [-c, a],
-            ])
+            ], dtype=object)
     else:
         raise NotImplementedError(
                 "inverse formula for %dx%d matrices" % (m, n))

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -851,10 +851,15 @@ def _small_mat_eigenvalues(mat):
         return make_obj_array([mat[0, 0]])
     elif m == 2:
         (a, b), (c, d) = mat
+        tr_mat = cse(a + d)
+        det_mat = a * d - b * c
+
+        # solutions to lambda**2 - tr(A) * lambda + det(A)
+        sqrt_discriminant = cse(sqrt(tr_mat**2 - 4*det_mat))
         return make_obj_array([
-                -(sqrt(d**2-2*a*d+4*b*c+a**2)-d-a)/2,
-                 (sqrt(d**2-2*a*d+4*b*c+a**2)+d+a)/2
-                ])
+            (tr_mat - sqrt_discriminant) / 2,
+            (tr_mat + sqrt_discriminant) / 2,
+            ])
     else:
         raise NotImplementedError(
                 "eigenvalue formula for %dx%d matrices" % (m, n))

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -827,7 +827,9 @@ def _panel_size(ambient_dim, dim=None, dofdesc=None):
 def _small_mat_inverse(mat):
     m, n = mat.shape
     if m != n:
-        raise ValueError("inverses only make sense for square matrices")
+        raise ValueError(
+                "inverses only make sense for square matrices: "
+                f"got a {m}x{n} matrix")
 
     if m == 1:
         return np.array([[1/mat[0, 0]]], dtype=object)
@@ -838,14 +840,15 @@ def _small_mat_inverse(mat):
             [-c, a],
             ], dtype=object)
     else:
-        raise NotImplementedError(
-                "inverse formula for %dx%d matrices" % (m, n))
+        raise NotImplementedError(f"inverse formula for {m}x{n} matrices")
 
 
 def _small_mat_eigenvalues(mat):
     m, n = mat.shape
     if m != n:
-        raise ValueError("eigenvalues only make sense for square matrices")
+        raise ValueError(
+                "eigenvalues only make sense for square matrices: "
+                f"got a {m}x{n} matrix")
 
     if m == 1:
         return make_obj_array([mat[0, 0]])
@@ -861,8 +864,7 @@ def _small_mat_eigenvalues(mat):
             (tr_mat + sqrt_discriminant) / 2,
             ])
     else:
-        raise NotImplementedError(
-                "eigenvalue formula for %dx%d matrices" % (m, n))
+        raise NotImplementedError(f"eigenvalue formula for {m}x{n} matrices")
 
 
 def _equilateral_parametrization_derivative_matrix(ambient_dim, dim=None,


### PR DESCRIPTION
* `_small_mat_inverse` wasn't returning a matrix of the same size as the input in either case, so it couldn't do `inv @ x` afterwards.
* `_small_mat_eivenvalues` was written out in gory detail, making it hard to read; should be a bit clearer now (?)