### PR TITLE
Use arraycontext instead of pyopencl

### DIFF
--- a/examples/cost.py
+++ b/examples/cost.py
@@ -209,4 +209,4 @@ def predict_cost(ctx):
 
 
 if __name__ == "__main__":
-    predict_cost(cl.create_some_context(0))
+    predict_cost(cl.create_some_context())

--- a/examples/fmm-error.py
+++ b/examples/fmm-error.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pyopencl as cl
 
 from arraycontext import thaw
 from meshmode.array_context import PyOpenCLArrayContext
@@ -14,6 +13,7 @@ def main():
     import logging
     logging.basicConfig(level=logging.WARNING)  # INFO for more progress info
 
+    import pyopencl as cl
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
@@ -85,11 +85,17 @@ def main():
         for i, elem in np.ndenumerate(sigma):
             sigma[i] = elem.astype(np.complex128)
 
-    fld_in_vol = bind(places, op, auto_where=("unaccel_qbx", "targets"))(
-            actx, sigma=sigma, k=k).get()
+    fld_in_vol = actx.to_numpy(
+            bind(
+                places, op, auto_where=("unaccel_qbx", "targets")
+                )(actx, sigma=sigma, k=k)
+            )
 
-    fmm_fld_in_vol = bind(places, op, auto_where=("qbx", "targets"))(
-            actx, sigma=sigma, k=k).get()
+    fmm_fld_in_vol = actx.to_numpy(
+            bind(
+                places, op, auto_where=("qbx", "targets")
+                )(actx, sigma=sigma, k=k)
+            )
 
     err = fmm_fld_in_vol-fld_in_vol
 

--- a/examples/helmholtz-dirichlet.py
+++ b/examples/helmholtz-dirichlet.py
@@ -1,7 +1,5 @@
 import numpy as np
 import numpy.linalg as la
-import pyopencl as cl
-import pyopencl.clmath  # noqa
 
 from arraycontext import thaw
 from meshmode.array_context import PyOpenCLArrayContext
@@ -29,6 +27,7 @@ def main(mesh_name="ellipse", visualize=False):
     import logging
     logging.basicConfig(level=logging.INFO)  # INFO for more progress info
 
+    import pyopencl as cl
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
@@ -169,7 +168,7 @@ def main(mesh_name="ellipse", visualize=False):
                     actx, sigma=gmres_result.solution, k=k))
     except QBXTargetAssociationFailedException as e:
         fplot.write_vtk_file("helmholtz-dirichlet-failed-targets.vts", [
-            ("failed", e.failed_target_flags.get(queue))
+            ("failed", actx.to_numpy(e.failed_target_flags))
             ])
         raise
 

--- a/examples/laplace-dirichlet-3d.py
+++ b/examples/laplace-dirichlet-3d.py
@@ -1,6 +1,4 @@
 import numpy as np
-import pyopencl as cl
-import pyopencl.clmath  # noqa
 
 from arraycontext import thaw
 from meshmode.array_context import PyOpenCLArrayContext
@@ -27,6 +25,7 @@ def main(mesh_name="torus", visualize=False):
     import logging
     logging.basicConfig(level=logging.WARNING)  # INFO for more progress info
 
+    import pyopencl as cl
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
@@ -154,7 +153,7 @@ def main(mesh_name="torus", visualize=False):
                 bind(places, representation_sym)(actx, sigma=sigma))
     except QBXTargetAssociationFailedException as e:
         fplot.write_vtk_file("laplace-dirichlet-3d-failed-targets.vts", [
-            ("failed", e.failed_target_flags.get(queue)),
+            ("failed", actx.to_numpy(e.failed_target_flags)),
             ])
         raise
 

--- a/examples/layerpot-3d.py
+++ b/examples/layerpot-3d.py
@@ -1,5 +1,4 @@
 import numpy as np
-import pyopencl as cl
 
 from arraycontext import thaw
 from meshmode.array_context import PyOpenCLArrayContext
@@ -20,6 +19,7 @@ def main(mesh_name="ellipsoid"):
     logger = logging.getLogger(__name__)
     logging.basicConfig(level=logging.WARNING)  # INFO for more progress info
 
+    import pyopencl as cl
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(queue, force_device_scalars=True)

--- a/examples/layerpot.py
+++ b/examples/layerpot.py
@@ -3,7 +3,6 @@ if enable_mayavi:
     from mayavi import mlab  # noqa
 
 import numpy as np
-import pyopencl as cl
 
 from arraycontext import thaw
 from meshmode.array_context import PyOpenCLArrayContext
@@ -26,6 +25,7 @@ def main(curve_fn=starfish, visualize=True):
     import logging
     logging.basicConfig(level=logging.WARNING)  # INFO for more progress info
 
+    import pyopencl as cl
     cl_ctx = cl.create_some_context()
     queue = cl.CommandQueue(cl_ctx)
     actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
@@ -53,7 +53,7 @@ def main(curve_fn=starfish, visualize=True):
 
     from pytential.target import PointsTarget
     fplot = FieldPlotter(np.zeros(2), extent=5, npoints=1000)
-    targets_dev = cl.array.to_device(queue, fplot.points)
+    targets_dev = actx.from_numpy(fplot.points)
 
     from pytential import GeometryCollection
     places = GeometryCollection({

--- a/pytential/qbx/cost.py
+++ b/pytential/qbx/cost.py
@@ -929,7 +929,7 @@ class _PythonQBXCostModel(AbstractQBXCostModel, _PythonFMMCostModel):
 
         if not isinstance(geo_data, ToHostTransferredGeoDataWrapper):
             assert isinstance(geo_data, QBXFMMGeometryData)
-            geo_data = ToHostTransferredGeoDataWrapper(queue, geo_data)
+            geo_data = ToHostTransferredGeoDataWrapper(geo_data)
 
         return AbstractQBXCostModel.qbx_cost_per_box(
             self, queue, geo_data, kernel, kernel_arguments, calibration_params
@@ -944,8 +944,7 @@ class _PythonQBXCostModel(AbstractQBXCostModel, _PythonFMMCostModel):
 
         if not isinstance(geo_data, ToHostTransferredGeoDataWrapper):
             assert isinstance(geo_data, QBXFMMGeometryData)
-            geo_data = ToHostTransferredGeoDataWrapper(queue, geo_data)
-            queue.finish()
+            geo_data = ToHostTransferredGeoDataWrapper(geo_data)
 
         return AbstractQBXCostModel.qbx_cost_per_stage(
             self, queue, geo_data, kernel, kernel_arguments, calibration_params

--- a/pytential/qbx/fmmlib.py
+++ b/pytential/qbx/fmmlib.py
@@ -160,9 +160,8 @@ class QBXFMMLibExpansionWrangler(FMMLibExpansionWrangler):
         # FMMLib is CPU-only. This wrapper gets the geometry out of
         # OpenCL-land.
 
-        with cl.CommandQueue(tree_indep.cl_context) as queue:
-            from pytential.qbx.utils import ToHostTransferredGeoDataWrapper
-            geo_data = ToHostTransferredGeoDataWrapper(queue, geo_data)
+        from pytential.qbx.utils import ToHostTransferredGeoDataWrapper
+        geo_data = ToHostTransferredGeoDataWrapper(geo_data)
 
         self.geo_data = geo_data
         self.qbx_order = qbx_order

--- a/pytential/qbx/geometry.py
+++ b/pytential/qbx/geometry.py
@@ -22,8 +22,6 @@ THE SOFTWARE.
 
 
 import numpy as np
-import pyopencl as cl
-import pyopencl.array  # noqa
 
 from pytools import memoize_method, log_process
 from arraycontext import PyOpenCLArrayContext, flatten, freeze
@@ -112,16 +110,13 @@ class QBXFMMGeometryDataCodeContainer(TreeCodeContainerMixin):
     def __init__(self, actx: PyOpenCLArrayContext, ambient_dim,
             tree_code_container, debug,
             _well_sep_is_n_away, _from_sep_smaller_crit):
-        self.array_context = actx
         self.ambient_dim = ambient_dim
         self.tree_code_container = tree_code_container
-        self.debug = debug
         self._well_sep_is_n_away = _well_sep_is_n_away
         self._from_sep_smaller_crit = _from_sep_smaller_crit
 
-    @property
-    def cl_context(self):
-        return self.array_context.context
+        self._setup_actx = actx.clone()
+        self.debug = debug
 
     @memoize_method
     def copy_targets_kernel(self):
@@ -148,7 +143,7 @@ class QBXFMMGeometryDataCodeContainer(TreeCodeContainerMixin):
     def build_traversal(self):
         from boxtree.traversal import FMMTraversalBuilder
         return FMMTraversalBuilder(
-                self.cl_context,
+                self._setup_actx.context,
                 well_sep_is_n_away=self._well_sep_is_n_away,
                 from_sep_smaller_crit=self._from_sep_smaller_crit,
                 )
@@ -202,20 +197,20 @@ class QBXFMMGeometryDataCodeContainer(TreeCodeContainerMixin):
     @memoize_method
     def build_leaf_to_ball_lookup(self):
         from boxtree.area_query import LeavesToBallsLookupBuilder
-        return LeavesToBallsLookupBuilder(self.cl_context)
+        return LeavesToBallsLookupBuilder(self._setup_actx.context)
 
     @property
     @memoize_method
     def key_value_sort(self):
         from pyopencl.algorithm import KeyValueSorter
-        return KeyValueSorter(self.cl_context)
+        return KeyValueSorter(self._setup_actx.context)
 
     @memoize_method
     def filter_center_and_target_ids(self, particle_id_dtype):
         from pyopencl.scan import GenericScanKernel
         from pyopencl.tools import VectorArg
         return GenericScanKernel(
-                self.cl_context, particle_id_dtype,
+                self._setup_actx.context, particle_id_dtype,
                 arguments=[
                     VectorArg(particle_id_dtype, "target_to_center"),
                     VectorArg(particle_id_dtype, "filtered_target_to_center"),
@@ -263,7 +258,7 @@ class QBXFMMGeometryDataCodeContainer(TreeCodeContainerMixin):
     @memoize_method
     def rotation_classes_builder(self):
         from boxtree.rotation_classes import RotationClassesBuilder
-        return RotationClassesBuilder(self.cl_context)
+        return RotationClassesBuilder(self._setup_actx.context)
 
 # }}}
 
@@ -332,21 +327,15 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
 
     .. attribute:: target_discrs_and_qbx_sides
 
-        a list of tuples ``(discr, sides)``, where
-        *discr* is a
-        :class:`meshmode.discretization.Discretization`
-        or a
-        :class:`pytential.target.TargetBase` instance, and
-        *sides* is an array of (:class:`numpy.int8`) side requests for each
-        target.
+        A :class:`list` of tuples ``(discr, sides)``, where *discr* is a
+        :class:`meshmode.discretization.Discretization` or a
+        :class:`pytential.target.TargetBase` instance, and *sides* is an
+        array of (:class:`numpy.int8`) side requests for each target.
 
         The side request can take on the values
         found in :ref:`qbx-side-request-table`.
 
-    .. attribute:: cl_context
-
-        A :class:`pyopencl.Context`.
-
+    .. attribute:: ambient_dim
     .. attribute:: coord_dtype
 
     .. rubric :: Expansion centers
@@ -410,12 +399,8 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
         return self.lpot_source.density_discr.real_dtype
 
     @property
-    def array_context(self):
-        return self.code_getter.array_context
-
-    @property
-    def cl_context(self):
-        return self.code_getter.cl_context
+    def _setup_actx(self):
+        return self.code_getter._setup_actx
 
     # {{{ centers/radii
 
@@ -431,7 +416,7 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
         """
         from pytential import bind, sym
 
-        actx = self.array_context
+        actx = self._setup_actx
         centers = bind(self.places, sym.interleaved_expansion_centers(
                 self.ambient_dim,
                 dofdesc=self.source_dd.to_stage1()))(actx)
@@ -447,7 +432,7 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
         """
         from pytential import bind, sym
 
-        actx = self.array_context
+        actx = self._setup_actx
         radii = bind(self.places,
                     sym.expansion_radii(
                         self.ambient_dim,
@@ -464,8 +449,8 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
     def target_info(self):
         """Return a :class:`TargetInfo`. |cached|"""
 
+        actx = self._setup_actx
         code_getter = self.code_getter
-        actx = self.array_context
         ntargets = self.ncenters
         target_discr_starts = []
 
@@ -491,9 +476,9 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
                     )
 
         return TargetInfo(
-                targets=targets,
+                targets=actx.freeze(targets),
                 target_discr_starts=target_discr_starts,
-                ntargets=ntargets).with_queue(None)
+                ntargets=ntargets)
 
     def target_side_preferences(self):
         """Return one big array combining all the data from
@@ -501,20 +486,18 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
 
         Shape: ``[ntargets]``, dtype: int8"""
 
+        actx = self._setup_actx
         tgt_info = self.target_info()
 
-        with cl.CommandQueue(self.array_context.context) as queue:
-            target_side_preferences = cl.array.empty(
-                    queue, tgt_info.ntargets, np.int8)
-            target_side_preferences[:self.ncenters] = 0
+        target_side_preferences = actx.empty(tgt_info.ntargets, dtype=np.int8)
+        target_side_preferences[:self.ncenters] = 0
 
-            for tdstart, (target_discr, qbx_side) in \
-                    zip(tgt_info.target_discr_starts,
-                            self.target_discrs_and_qbx_sides):
-                target_side_preferences[tdstart:tdstart+target_discr.ndofs] \
-                    = qbx_side
+        for tdstart, (target_discr, qbx_side) in zip(
+                tgt_info.target_discr_starts,
+                self.target_discrs_and_qbx_sides):
+            target_side_preferences[tdstart:tdstart+target_discr.ndofs] = qbx_side
 
-            return target_side_preferences.with_queue(None)
+        return actx.freeze(target_side_preferences)
 
     # }}}
 
@@ -528,12 +511,10 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
         |cached|
         """
 
+        actx = self._setup_actx
         code_getter = self.code_getter
         lpot_source = self.lpot_source
         target_info = self.target_info()
-
-        actx = self.array_context
-        queue = actx.queue
 
         from pytential import sym
         quad_stage2_discr = self.places.get_discretization(
@@ -544,11 +525,10 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
 
         target_radii = None
         if lpot_source._expansions_in_tree_have_extent:
-            target_radii = cl.array.zeros(queue, target_info.ntargets,
-                    self.coord_dtype)
+            target_radii = actx.zeros(target_info.ntargets, self.coord_dtype)
             target_radii[:self.ncenters] = self.flat_expansion_radii()
 
-        refine_weights = cl.array.empty(queue, nparticles, dtype=np.int32)
+        refine_weights = actx.empty(nparticles, dtype=np.int32)
 
         # Assign a weight of 1 to all sources, QBX centers, and conventional
         # (non-QBX) targets. Assign a weight of 0 to all targets that need
@@ -556,13 +536,13 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
         # entirely by the QBX center, so as a matter of evaluation cost,
         # their location in the tree is irrelevant.
         refine_weights[:-target_info.ntargets] = 1
-        user_ttc = self.user_target_to_center().with_queue(queue)
+        user_ttc = actx.thaw(self.user_target_to_center())
         refine_weights[-target_info.ntargets:] = (
                 user_ttc == target_state.NO_QBX_NEEDED).astype(np.int32)
 
         refine_weights.finish()
 
-        tree, _ = code_getter.build_tree()(queue,
+        tree, _ = code_getter.build_tree()(actx.queue,
                 particles=flatten(
                     quad_stage2_discr.nodes(), actx, leaf_class=DOFArray
                     ),
@@ -576,12 +556,10 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
                 kind=self.tree_kind)
 
         if self.debug:
-            tgt_count_2 = cl.array.sum(
-                    tree.box_target_counts_nonchild, queue=queue).get()
-
+            tgt_count_2 = actx.to_numpy(actx.np.sum(tree.box_target_counts_nonchild))
             assert (tree.ntargets == tgt_count_2), (tree.ntargets, tgt_count_2)
 
-        return tree
+        return tree.with_queue(None)
 
     # }}}
 
@@ -595,17 +573,16 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
         |cached|
         """
 
-        with cl.CommandQueue(self.cl_context) as queue:
-            trav, _ = self.code_getter.build_traversal(queue, self.tree(),
-                    debug=self.debug,
-                    _from_sep_smaller_min_nsources_cumul=(
-                        self.lpot_source._from_sep_smaller_min_nsources_cumul))
+        actx = self._setup_actx
+        trav, _ = self.code_getter.build_traversal(actx.queue, self.tree(),
+                debug=self.debug,
+                _from_sep_smaller_min_nsources_cumul=(
+                    self.lpot_source._from_sep_smaller_min_nsources_cumul))
 
-            if (merge_close_lists
-                    and self.lpot_source._expansions_in_tree_have_extent):
-                trav = trav.merge_close_lists(queue)
+        if merge_close_lists and self.lpot_source._expansions_in_tree_have_extent:
+            trav = trav.merge_close_lists(actx.queue)
 
-            return trav
+        return trav.with_queue(None)
 
     @memoize_method
     def qbx_center_to_target_box(self):
@@ -615,6 +592,7 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
 
         |cached|
         """
+        actx = self._setup_actx
         tree = self.tree()
         trav = self.traversal()
 
@@ -626,45 +604,44 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
                         tree.box_id_dtype,
                         )
 
-        with cl.CommandQueue(self.cl_context) as queue:
-            box_to_target_box = cl.array.empty(
-                    queue, tree.nboxes, tree.box_id_dtype)
-            if self.debug:
-                box_to_target_box.fill(-1)
-            box_to_target_box[trav.target_boxes] = cl.array.arange(
-                    queue, len(trav.target_boxes), dtype=tree.box_id_dtype)
+        box_to_target_box = actx.empty(tree.nboxes, tree.box_id_dtype)
+        if self.debug:
+            box_to_target_box.fill(-1)
 
-            sorted_target_ids = self.tree().sorted_target_ids
-            user_target_from_tree_target = \
-                    cl.array.empty_like(sorted_target_ids).with_queue(queue)
+        box_to_target_box[trav.target_boxes] = actx.from_numpy(
+                np.arange(len(trav.target_boxes), dtype=tree.box_id_dtype)
+                )
 
-            user_target_from_tree_target[sorted_target_ids] = \
-                    cl.array.arange(
-                            queue, len(sorted_target_ids),
-                            user_target_from_tree_target.dtype)
+        sorted_target_ids = self.tree().sorted_target_ids
+        user_target_from_tree_target = actx.empty_like(sorted_target_ids)
 
-            qbx_center_to_target_box = cl.array.empty(
-                    queue, self.ncenters, tree.box_id_dtype)
+        user_target_from_tree_target[sorted_target_ids] = actx.from_numpy(
+                np.arange(
+                    len(sorted_target_ids),
+                    dtype=user_target_from_tree_target.dtype)
+                )
 
-            if self.debug:
-                qbx_center_to_target_box.fill(-1)
+        qbx_center_to_target_box = actx.empty(self.ncenters, tree.box_id_dtype)
 
-            evt, _ = qbx_center_to_target_box_lookup(
-                    queue,
-                    qbx_center_to_target_box=qbx_center_to_target_box,
-                    box_to_target_box=box_to_target_box,
-                    box_target_starts=tree.box_target_starts,
-                    box_target_counts_nonchild=tree.box_target_counts_nonchild,
-                    user_target_from_tree_target=user_target_from_tree_target,
-                    ncenters=self.ncenters)
+        if self.debug:
+            qbx_center_to_target_box.fill(-1)
 
-            if self.debug:
-                assert 0 <= cl.array.min(qbx_center_to_target_box).get()
-                assert (
-                        cl.array.max(qbx_center_to_target_box).get()
-                        < len(trav.target_boxes))
+        evt, _ = qbx_center_to_target_box_lookup(
+                actx.queue,
+                qbx_center_to_target_box=qbx_center_to_target_box,
+                box_to_target_box=box_to_target_box,
+                box_target_starts=tree.box_target_starts,
+                box_target_counts_nonchild=tree.box_target_counts_nonchild,
+                user_target_from_tree_target=user_target_from_tree_target,
+                ncenters=self.ncenters)
 
-            return qbx_center_to_target_box.with_queue(None)
+        if self.debug:
+            assert 0 <= actx.to_numpy(actx.np.min(qbx_center_to_target_box))
+            assert (
+                    actx.to_numpy(actx.np.max(qbx_center_to_target_box))
+                    < len(trav.target_boxes))
+
+        return actx.freeze(qbx_center_to_target_box)
 
     @memoize_method
     def qbx_center_to_target_box_source_level(self, source_level):
@@ -673,28 +650,28 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
         ``traversal.from_sep_smaller_by_level[source_level].``
         -1 if no such interaction list exist on *source_level*.
         """
+        actx = self._setup_actx
+
         traversal = self.traversal()
         sep_smaller = traversal.from_sep_smaller_by_level[source_level]
         qbx_center_to_target_box = self.qbx_center_to_target_box()
 
-        with cl.CommandQueue(self.cl_context) as queue:
-            target_box_to_target_box_source_level = cl.array.empty(
-                queue, len(traversal.target_boxes),
-                dtype=traversal.tree.box_id_dtype
-            )
-            target_box_to_target_box_source_level.fill(-1)
-            target_box_to_target_box_source_level[sep_smaller.nonempty_indices] = (
-                cl.array.arange(queue, sep_smaller.num_nonempty_lists,
-                                dtype=traversal.tree.box_id_dtype)
+        target_box_to_target_box_source_level = actx.empty(
+            len(traversal.target_boxes), dtype=traversal.tree.box_id_dtype)
+        target_box_to_target_box_source_level.fill(-1)
+        target_box_to_target_box_source_level[sep_smaller.nonempty_indices] = (
+                actx.from_numpy(
+                    np.arange(
+                        sep_smaller.num_nonempty_lists,
+                        dtype=traversal.tree.box_id_dtype)
+                    )
+                )
+
+        qbx_center_to_target_box_source_level = (
+            target_box_to_target_box_source_level[qbx_center_to_target_box]
             )
 
-            qbx_center_to_target_box_source_level = (
-                target_box_to_target_box_source_level[
-                    qbx_center_to_target_box
-                ]
-            )
-
-            return qbx_center_to_target_box_source_level.with_queue(None)
+        return actx.freeze(qbx_center_to_target_box_source_level)
 
     @memoize_method
     def global_qbx_flags(self):
@@ -709,12 +686,12 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
 
         |cached|
         """
+        actx = self._setup_actx
 
-        with cl.CommandQueue(self.cl_context) as queue:
-            result = cl.array.empty(queue, self.ncenters, np.int8)
-            result.fill(1)
+        result = actx.empty(self.ncenters, np.int8)
+        result.fill(1)
 
-        return result.with_queue(None)
+        return actx.freeze(result)
 
     @memoize_method
     @log_process(logger)
@@ -725,40 +702,39 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
 
         Centers without any associated targets are excluded.
         """
-
+        actx = self._setup_actx
         tree = self.tree()
-        user_target_to_center = self.user_target_to_center()
+        user_target_to_center = actx.thaw(self.user_target_to_center())
 
-        with cl.CommandQueue(self.cl_context) as queue:
-            tgt_assoc_result = (
-                    user_target_to_center.with_queue(queue)[self.ncenters:])
+        tgt_assoc_result = user_target_to_center[self.ncenters:]
+        center_is_used = actx.zeros(self.ncenters, np.int8)
 
-            center_is_used = cl.array.zeros(queue, self.ncenters, np.int8)
+        self.code_getter.pick_used_centers(
+                actx.queue,
+                center_is_used=center_is_used,
+                target_to_center=tgt_assoc_result,
+                ncenters=self.ncenters,
+                ntargets=len(tgt_assoc_result))
 
-            self.code_getter.pick_used_centers(
-                    queue,
-                    center_is_used=center_is_used,
-                    target_to_center=tgt_assoc_result,
-                    ncenters=self.ncenters,
-                    ntargets=len(tgt_assoc_result))
+        from pyopencl.algorithm import copy_if
+        icenters = actx.from_numpy(
+                np.arange(self.ncenters, dtype=tree.particle_id_dtype)
+                )
+        result, count, _ = copy_if(
+                icenters,
+                "global_qbx_flags[i] != 0 && center_is_used[i] != 0",
+                extra_args=[
+                    ("global_qbx_flags", self.global_qbx_flags()),
+                    ("center_is_used", center_is_used)
+                    ],
+                queue=actx.queue)
 
-            from pyopencl.algorithm import copy_if
+        count = actx.to_numpy(count).item()
+        if self.debug:
+            logger.debug("find global qbx centers: using %d/%d centers",
+                    count, self.ncenters)
 
-            result, count, _ = copy_if(
-                    cl.array.arange(queue, self.ncenters,
-                        tree.particle_id_dtype),
-                    "global_qbx_flags[i] != 0 && center_is_used[i] != 0",
-                    extra_args=[
-                        ("global_qbx_flags", self.global_qbx_flags()),
-                        ("center_is_used", center_is_used)
-                        ],
-                    queue=queue)
-
-            if self.debug:
-                logger.debug("find global qbx centers: using %d/%d centers",
-                        int(count.get()), self.ncenters)
-
-            return result[:count.get()].with_queue(None)
+        return actx.freeze(result[:count])
 
     @memoize_method
     def user_target_to_center(self):
@@ -770,15 +746,14 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
         Shape: ``[ntargets]`` of :attr:`boxtree.Tree.particle_id_dtype`, with extra
         values from :class:`target_state` allowed. Targets occur in user order.
         """
+        actx = self._setup_actx
+
         from pytential.qbx.target_assoc import associate_targets_to_qbx_centers
         target_info = self.target_info()
 
         from pytential.target import PointsTarget
-
-        queue = self.array_context.queue
-
-        target_side_prefs = (self
-                .target_side_preferences()[self.ncenters:].get(queue=queue))
+        target_side_prefs = actx.thaw(self.target_side_preferences())
+        target_side_prefs = actx.to_numpy(target_side_prefs[self.ncenters:])
 
         target_discrs_and_qbx_sides = [(
                 PointsTarget(target_info.targets[:, self.ncenters:]),
@@ -786,7 +761,7 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
 
         target_association_wrangler = (
                 self.lpot_source.target_association_code_container
-                .get_wrangler(self.array_context))
+                .get_wrangler(actx))
 
         tgt_assoc_result = associate_targets_to_qbx_centers(
                 self.places,
@@ -797,52 +772,48 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
                     self.target_association_tolerance),
                 debug=self.debug)
 
-        result = cl.array.empty(queue, target_info.ntargets,
-                tgt_assoc_result.target_to_center.dtype)
+        result = actx.empty(
+                target_info.ntargets, tgt_assoc_result.target_to_center.dtype
+                )
         result[:self.ncenters].fill(target_state.NO_QBX_NEEDED)
         result[self.ncenters:] = tgt_assoc_result.target_to_center
 
-        return result.with_queue(None)
+        return actx.freeze(result)
 
     @memoize_method
     @log_process(logger)
     def center_to_tree_targets(self):
         """Return a :class:`CenterToTargetList`. See :meth:`user_target_to_center`
         for the reverse look-up table with targets in user order.
-
         |cached|
         """
 
+        actx = self._setup_actx
         user_ttc = self.user_target_to_center()
 
-        with cl.CommandQueue(self.cl_context) as queue:
-            tree_ttc = cl.array.empty_like(user_ttc).with_queue(queue)
-            tree_ttc[self.tree().sorted_target_ids] = user_ttc
+        tree_ttc = actx.empty_like(user_ttc)
+        tree_ttc[self.tree().sorted_target_ids] = user_ttc
 
-            filtered_tree_ttc = cl.array.empty(queue, tree_ttc.shape, tree_ttc.dtype)
-            filtered_target_ids = cl.array.empty(
-                    queue, tree_ttc.shape, tree_ttc.dtype)
-            count = cl.array.empty(queue, 1, tree_ttc.dtype)
+        filtered_tree_ttc = actx.empty(tree_ttc.shape, dtype=tree_ttc.dtype)
+        filtered_target_ids = actx.empty(tree_ttc.shape, dtype=tree_ttc.dtype)
+        count = actx.empty(1, dtype=tree_ttc.dtype)
 
-            self.code_getter.filter_center_and_target_ids(tree_ttc.dtype)(
-                    tree_ttc, filtered_tree_ttc, filtered_target_ids, count,
-                    queue=queue, size=len(tree_ttc))
+        self.code_getter.filter_center_and_target_ids(tree_ttc.dtype)(
+                tree_ttc, filtered_tree_ttc, filtered_target_ids, count,
+                queue=actx.queue, size=len(tree_ttc))
 
-            count = count.get().item()
+        count = actx.to_numpy(count).item()
+        filtered_tree_ttc = filtered_tree_ttc[:count]
+        filtered_target_ids = actx.np.copy(filtered_target_ids[:count])
 
-            filtered_tree_ttc = filtered_tree_ttc[:count]
-            filtered_target_ids = filtered_target_ids[:count].copy()
+        center_target_starts, targets_sorted_by_center, _ = \
+                self.code_getter.key_value_sort(actx.queue,
+                        filtered_tree_ttc, filtered_target_ids,
+                        self.ncenters, tree_ttc.dtype)
 
-            center_target_starts, targets_sorted_by_center, _ = \
-                    self.code_getter.key_value_sort(queue,
-                            filtered_tree_ttc, filtered_target_ids,
-                            self.ncenters, tree_ttc.dtype)
-
-            result = CenterToTargetList(
-                    starts=center_target_starts,
-                    lists=targets_sorted_by_center).with_queue(None)
-
-            return result
+        return CenterToTargetList(
+                starts=actx.freeze(center_target_starts),
+                lists=actx.freeze(targets_sorted_by_center))
 
     @memoize_method
     @log_process(logger)
@@ -854,34 +825,31 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
 
         |cached|
         """
+        actx = self._setup_actx
+        flags = actx.thaw(self.user_target_to_center()) == target_state.NO_QBX_NEEDED
 
-        with cl.CommandQueue(self.cl_context) as queue:
-            flags = (self.user_target_to_center().with_queue(queue)
-                    == target_state.NO_QBX_NEEDED)
+        # The QBX centers come up with NO_QBX_NEEDED, but they don't
+        # belong in this target list.
 
-            # The QBX centers come up with NO_QBX_NEEDED, but they don't
-            # belong in this target list.
+        # 'flags' is in user order, and should be.
 
-            # 'flags' is in user order, and should be.
+        nqbx_centers = self.ncenters
+        flags[:nqbx_centers] = 0
 
-            nqbx_centers = self.ncenters
-            flags[:nqbx_centers] = 0
+        tree = self.tree()
+        plfilt = self.code_getter.particle_list_filter()
+        result = plfilt.filter_target_lists_in_tree_order(actx.queue, tree, flags)
 
-            tree = self.tree()
-            plfilt = self.code_getter.particle_list_filter()
-            result = plfilt.filter_target_lists_in_tree_order(queue, tree, flags)
-
-            return result.with_queue(None)
+        return result.with_queue(None)
 
     @memoize_method
     def build_rotation_classes_lists(self):
+        actx = self._setup_actx
         trav = self.traversal()
         tree = self.tree()
 
-        with cl.CommandQueue(self.cl_context) as queue:
-            return (self
-                    .code_getter
-                    .rotation_classes_builder(queue, trav, tree)[0].get(queue))
+        result = self.code_getter.rotation_classes_builder(actx.queue, trav, tree)
+        return actx.to_numpy(result[0])
 
     @memoize_method
     def m2l_rotation_lists(self):
@@ -916,99 +884,98 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
         if dims != 2:
             raise ValueError("only 2-dimensional geometry info can be plotted")
 
-        with cl.CommandQueue(self.cl_context) as queue:
-            stage2_density_discr = self.places.get_discretization(
-                    self.source_dd.geometry, sym.QBX_SOURCE_STAGE2)
-            quad_stage2_density_discr = self.places.get_discretization(
-                    self.source_dd.geometry, sym.QBX_SOURCE_QUAD_STAGE2)
-            from meshmode.discretization.visualization import draw_curve
-            draw_curve(quad_stage2_density_discr)
+        actx = self._setup_actx
+        stage2_density_discr = self.places.get_discretization(
+                self.source_dd.geometry, sym.QBX_SOURCE_STAGE2)
+        quad_stage2_density_discr = self.places.get_discretization(
+                self.source_dd.geometry, sym.QBX_SOURCE_QUAD_STAGE2)
 
-            global_flags = self.global_qbx_flags().get(queue=queue)
+        from meshmode.discretization.visualization import draw_curve
+        draw_curve(quad_stage2_density_discr)
 
-            tree = self.tree().get(queue=queue)
-            from boxtree.visualization import TreePlotter
-            tp = TreePlotter(tree)
-            tp.draw_tree()
+        global_flags = actx.to_numpy(self.global_qbx_flags())
 
-            # {{{ draw centers and circles
+        tree = self.tree().get(queue=actx.queue)
+        from boxtree.visualization import TreePlotter
+        tp = TreePlotter(tree)
+        tp.draw_tree()
 
-            centers = self.flat_centers()
-            centers = [
-                    centers[0].get(queue),
-                    centers[1].get(queue)]
-            pt.plot(centers[0][global_flags == 0],
-                    centers[1][global_flags == 0], "oc",
-                    label="centers needing local qbx")
+        # {{{ draw centers and circles
 
-            if highlight_centers is not None:
-                pt.plot(centers[0][highlight_centers],
-                        centers[1][highlight_centers], "oc",
-                        label="highlighted centers",
-                        markersize=15)
+        centers = self.flat_centers()
+        centers = [actx.to_numpy(centers[0]), actx.to_numpy(centers[1])]
+        pt.plot(centers[0][global_flags == 0],
+                centers[1][global_flags == 0], "oc",
+                label="centers needing local qbx")
 
-            ax = pt.gca()
+        if highlight_centers is not None:
+            pt.plot(centers[0][highlight_centers],
+                    centers[1][highlight_centers], "oc",
+                    label="highlighted centers",
+                    markersize=15)
 
-            if draw_circles:
-                for cx, cy, r in zip(
-                        centers[0], centers[1],
-                        self.flat_expansion_radii().get(queue)):
-                    ax.add_artist(
-                            pt.Circle((cx, cy), r, fill=False, ls="dotted", lw=1))
+        ax = pt.gca()
 
-            if draw_center_numbers:
-                for icenter, (cx, cy) in enumerate(zip(centers[0], centers[1])):
-                    pt.text(cx, cy,
-                            str(icenter), fontsize=8,
-                            ha="left", va="center",
-                            bbox=dict(facecolor="white", alpha=0.5, lw=0))
+        if draw_circles:
+            for cx, cy, r in zip(
+                    centers[0], centers[1],
+                    actx.to_numpy(self.flat_expansion_radii())):
+                ax.add_artist(pt.Circle((cx, cy), r,
+                    fill=False, ls="dotted", lw=1))
 
-            # }}}
+        if draw_center_numbers:
+            for icenter, (cx, cy) in enumerate(zip(centers[0], centers[1])):
+                pt.text(cx, cy,
+                    str(icenter), fontsize=8,
+                    ha="left", va="center",
+                    bbox=dict(facecolor="white", alpha=0.5, lw=0))
 
-            # {{{ draw target-to-center arrows
+        # }}}
 
-            ttc = self.user_target_to_center().get(queue)
-            tinfo = self.target_info()
-            targets = tinfo.targets.get(queue)
+        # {{{ draw target-to-center arrows
 
-            pt.plot(targets[0], targets[1], "+")
-            pt.plot(
-                    targets[0][ttc == target_state.FAILED],
-                    targets[1][ttc == target_state.FAILED],
-                    "dr", markersize=15, label="failed targets")
+        ttc = actx.to_numpy(self.user_target_to_center())
+        tinfo = self.target_info()
+        targets = actx.to_numpy(tinfo.targets)
 
-            for itarget in np.where(ttc == target_state.FAILED)[0]:
-                pt.text(
-                        targets[0][itarget],
-                        targets[1][itarget],
-                        str(itarget), fontsize=8,
-                        ha="left", va="center",
-                        bbox=dict(facecolor="white", alpha=0.5, lw=0))
+        pt.plot(targets[0], targets[1], "+")
+        pt.plot(
+                targets[0][ttc == target_state.FAILED],
+                targets[1][ttc == target_state.FAILED],
+                "dr", markersize=15, label="failed targets")
 
-            tccount = 0
-            checked = 0
-            for tx, ty, tcenter in zip(
-                    targets[0][self.ncenters:],
-                    targets[1][self.ncenters:],
-                    ttc[self.ncenters:]):
-                checked += 1
-                if tcenter >= 0:
-                    tccount += 1
-                    ax.add_artist(
-                            pt.Line2D(
-                                (tx, centers[0][tcenter]),
-                                (ty, centers[1][tcenter]),
-                                ))
+        for itarget in np.where(ttc == target_state.FAILED)[0]:
+            pt.text(
+                    targets[0][itarget],
+                    targets[1][itarget],
+                    str(itarget), fontsize=8,
+                    ha="left", va="center",
+                    bbox=dict(facecolor="white", alpha=0.5, lw=0))
 
-            logger.info("found a center for %d/%d targets", tccount, checked)
+        tccount = 0
+        checked = 0
+        for tx, ty, tcenter in zip(
+                targets[0][self.ncenters:],
+                targets[1][self.ncenters:],
+                ttc[self.ncenters:]):
+            checked += 1
+            if tcenter >= 0:
+                tccount += 1
+                ax.add_artist(
+                    pt.Line2D(
+                        (tx, centers[0][tcenter]),
+                        (ty, centers[1][tcenter]),
+                        ))
 
-            # }}}
+        logger.info("found a center for %d/%d targets", tccount, checked)
 
-            pt.gca().set_aspect("equal")
-            #pt.legend()
-            pt.savefig(
-                    "geodata-stage2-nelem%d.pdf"
-                    % stage2_density_discr.mesh.nelements)
+        # }}}
+
+        pt.gca().set_aspect("equal")
+        #pt.legend()
+        pt.savefig(
+                "geodata-stage2-nelem%d.pdf"
+                % stage2_density_discr.mesh.nelements)
 
     # }}}
 

--- a/test/test_cost_model.py
+++ b/test/test_cost_model.py
@@ -89,7 +89,7 @@ def test_compare_cl_and_py_cost_model(actx_factory):
     )
 
     from pytential.qbx.utils import ToHostTransferredGeoDataWrapper
-    geo_data = ToHostTransferredGeoDataWrapper(queue, geo_data_dev)
+    geo_data = ToHostTransferredGeoDataWrapper(geo_data_dev)
 
     # }}}
 
@@ -158,7 +158,7 @@ def test_compare_cl_and_py_cost_model(actx_factory):
         str(time.time() - start_time)
     ))
 
-    assert np.array_equal(cl_p2qbxl.get(), python_p2qbxl)
+    assert np.array_equal(actx.to_numpy(cl_p2qbxl), python_p2qbxl)
 
     # }}}
 
@@ -186,7 +186,7 @@ def test_compare_cl_and_py_cost_model(actx_factory):
         str(time.time() - start_time)
     ))
 
-    assert np.array_equal(cl_m2qbxl.get(), python_m2qbxl)
+    assert np.array_equal(actx.to_numpy(cl_m2qbxl), python_m2qbxl)
 
     # }}}
 
@@ -214,7 +214,7 @@ def test_compare_cl_and_py_cost_model(actx_factory):
         str(time.time() - start_time)
     ))
 
-    assert np.array_equal(cl_l2qbxl.get(), python_l2qbxl)
+    assert np.array_equal(actx.to_numpy(cl_l2qbxl), python_l2qbxl)
 
     # }}}
 
@@ -242,7 +242,7 @@ def test_compare_cl_and_py_cost_model(actx_factory):
         str(time.time() - start_time)
     ))
 
-    assert np.array_equal(cl_eval_qbxl.get(), python_eval_qbxl)
+    assert np.array_equal(actx.to_numpy(cl_eval_qbxl), python_eval_qbxl)
 
     # }}}
 
@@ -274,7 +274,8 @@ def test_compare_cl_and_py_cost_model(actx_factory):
     ))
 
     assert np.array_equal(
-        cl_eval_target_specific_qbxl.get(), python_eval_target_specific_qbxl
+        actx.to_numpy(cl_eval_target_specific_qbxl),
+        python_eval_target_specific_qbxl
     )
 
     # }}}
@@ -485,7 +486,7 @@ class ConstantOneQBXExpansionWrangler(ConstantOneExpansionWrangler):
     def __init__(self, tree_indep, queue, geo_data,
             use_target_specific_qbx):
         from pytential.qbx.utils import ToHostTransferredGeoDataWrapper
-        geo_data = ToHostTransferredGeoDataWrapper(queue, geo_data)
+        geo_data = ToHostTransferredGeoDataWrapper(geo_data)
 
         self.geo_data = geo_data
         self.trav = geo_data.traversal()
@@ -761,7 +762,7 @@ def test_cost_model_correctness(actx_factory, dim, off_surface,
             traversal=wrangler.trav)[0][geo_data.ncenters:]
 
     # Check constant one wrangler for correctness.
-    assert (potential == ndofs).all()
+    assert np.all(potential == ndofs)
 
     # Check that the cost model matches the timing data returned by the
     # constant one wrangler.

--- a/test/test_layer_pot.py
+++ b/test/test_layer_pot.py
@@ -218,7 +218,6 @@ def test_off_surface_eval_vs_direct(actx_factory,  do_plot=False):
     print("l_inf error:", linf_err)
 
     if do_plot:
-        #fplot.show_scalar_in_mayavi(0.1*.get(queue))
         fplot.write_vtk_file("potential.vts", [
             ("fmm_fld_in_vol", actx.to_numpy(fmm_fld_in_vol)),
             ("direct_fld_in_vol", actx.to_numpy(direct_fld_in_vol))
@@ -308,7 +307,6 @@ def test_single_plus_double_with_single_fmm(actx_factory,  do_plot=False):
     print("l_inf error:", linf_err)
 
     if do_plot:
-        #fplot.show_scalar_in_mayavi(0.1*.get(queue))
         fplot.write_vtk_file("potential.vts", [
             ("fmm_fld_in_vol", actx.to_numpy(fmm_fld_in_vol)),
             ("direct_fld_in_vol", actx.to_numpy(direct_fld_in_vol))

--- a/test/test_maxwell.py
+++ b/test/test_maxwell.py
@@ -24,9 +24,6 @@ import pytest
 
 import numpy as np
 
-import pyopencl as cl
-import pyopencl.clrandom
-
 from pytential import bind, sym, norm
 from pytential.target import PointsTarget
 from sumpy.visualization import make_field_plotter_from_bbox  # noqa
@@ -243,7 +240,9 @@ def test_pec_mfie_extinction(actx_factory, case,
     calc_patch = CalculusPatch(np.array([-3, 0, 0]), h=0.01)
     calc_patch_tgt = PointsTarget(actx.from_numpy(calc_patch.points))
 
-    rng = cl.clrandom.PhiloxGenerator(actx.context, seed=12)
+    import pyopencl.clrandom as clrandom
+    rng = clrandom.PhiloxGenerator(actx.context, seed=12)
+
     from pytools.obj_array import make_obj_array
     src_j = make_obj_array([
             rng.normal(actx.queue, (test_source.ndofs), dtype=np.float64)


### PR DESCRIPTION
Inspired by inducer/arraycontext#111, this tried to remove some of the direct usage of `pyopencl`. It's still a far shot from actually working with `TaggedCLArray` transparently, but it's a start! This mostly removes uses of
* `cl.array` parts which are in `arraycontext`
* `ary.with_queue(queue)` with `actx.thaw` or `actx.freeze`
* `ary.get()` with `actx.from_numpy`

A few obvious places where `pyopencl` is still used:
* some calls to `cl.wait_for_events`; not sure how necessary this is?
* some calls to `pyopencl.algoritm`: `copy_if`
* some calls to `pyopencl.array`: `take`.
* some kernels: `ElementwiseKernel`, `GenericScanKernel`

The main roadblock however seems to be that all the `sumpy` calls return bare `cl.array.Array` and generally don't know anything about array contexts.