### PR TITLE
Per-node stretch factors

### DIFF
--- a/pytential/qbx/refinement.py
+++ b/pytential/qbx/refinement.py
@@ -311,9 +311,8 @@ class RefinerWrangler(TreeWranglerBase):
         center_danger_zone_radii = flatten(
             bind(
                 stage1_density_discr,
-                sym.interleave(
-                    sym.expansion_radii(stage1_density_discr.ambient_dim),
-                    )
+                sym.interp(None, sym.GRANULARITY_CENTER,
+                    sym.expansion_radii(stage1_density_discr.ambient_dim))
                 )(self.array_context),
             self.array_context)
 

--- a/pytential/qbx/refinement.py
+++ b/pytential/qbx/refinement.py
@@ -608,9 +608,6 @@ def _refine_qbx_stage1(lpot_source, density_discr,
         iter_violated_criteria = []
         niter += 1
 
-        logger.debug("[stage1] niter %4d nelements %8d ndofs %8d",
-            niter, stage1_density_discr.mesh.nelements, stage1_density_discr.ndofs)
-
         if niter > maxiter:
             _warn_max_iterations(
                     violated_criteria, expansion_disturbance_tolerance)
@@ -622,12 +619,10 @@ def _refine_qbx_stage1(lpot_source, density_discr,
             with ProcessLogger(logger,
                     "checking kernel length scale to element size ratio"):
 
-                quad_resolution_by_element = bind(
-                        stage1_density_discr,
+                quad_resolution_by_element = bind(stage1_density_discr,
                         sym.ElementwiseMax(
                             sym._quad_resolution(stage1_density_discr.ambient_dim),
-                            dofdesc=sym.GRANULARITY_ELEMENT)
-                        )(actx)
+                            dofdesc=sym.GRANULARITY_ELEMENT))(actx)
 
                 violates_kernel_length_scale = \
                         wrangler.check_element_prop_threshold(
@@ -647,8 +642,7 @@ def _refine_qbx_stage1(lpot_source, density_discr,
                 scaled_max_curvature_by_element = bind(stage1_density_discr,
                     sym.ElementwiseMax(
                         sym._scaled_max_curvature(stage1_density_discr.ambient_dim),
-                        dofdesc=sym.GRANULARITY_ELEMENT)
-                    )(actx)
+                        dofdesc=sym.GRANULARITY_ELEMENT))(actx)
 
                 violates_scaled_max_curv = \
                         wrangler.check_element_prop_threshold(
@@ -689,8 +683,6 @@ def _refine_qbx_stage1(lpot_source, density_discr,
             del peer_lists
 
         if iter_violated_criteria:
-            logger.debug("[stage1] violated_criteria: %s",
-                    " and ".join(iter_violated_criteria))
             violated_criteria.append(" and ".join(iter_violated_criteria))
 
             conn = wrangler.refine(
@@ -736,9 +728,6 @@ def _refine_qbx_stage2(lpot_source, stage1_density_discr,
         iter_violated_criteria = []
         niter += 1
 
-        logger.debug("[stage2] niter %4d nelements %8d ndofs %8d",
-            niter, stage2_density_discr.mesh.nelements, stage2_density_discr.ndofs)
-
         if niter > maxiter:
             _warn_max_iterations(
                     violated_criteria, expansion_disturbance_tolerance)
@@ -767,8 +756,6 @@ def _refine_qbx_stage2(lpot_source, stage1_density_discr,
                     visualize=visualize)
 
         if iter_violated_criteria:
-            logger.debug("[stage2] violated_criteria: %s",
-                    " and ".join(iter_violated_criteria))
             violated_criteria.append(" and ".join(iter_violated_criteria))
 
             conn = wrangler.refine(

--- a/pytential/symbolic/dof_connection.py
+++ b/pytential/symbolic/dof_connection.py
@@ -118,11 +118,14 @@ class CenterGranularityConnection(GranularityConnection):
                 raise ValueError("dtype mismatch in inputs: "
                     f"'{subary1.dtype.name}' and '{subary2.dtype.name}'")
 
+            assert subary1.shape[0] == grp.nelements
+            assert subary1.shape == subary2.shape
+
             result = actx.call_loopy(
                     prg(),
                     ary1=subary1, ary2=subary2,
-                    nelements=grp.nelements,
-                    nunit_dofs=grp.nunit_dofs)["result"]
+                    nelements=subary1.shape[0],
+                    nunit_dofs=subary1.shape[1])["result"]
             results.append(result)
 
         return DOFArray(actx, tuple(results))

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -1230,6 +1230,11 @@ def interp(from_dd, to_dd, operand):
     return Interpolation(from_dd, to_dd, operand)
 
 
+def interleave(operand, dofdesc=None):
+    dofdesc = as_dofdesc(dofdesc)
+    return interp(dofdesc, dofdesc.copy(granularity=GRANULARITY_CENTER), operand)
+
+
 class SingleScalarOperandExpression(Expression):
 
     init_arg_names = ("operand",)

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -1225,11 +1225,6 @@ def interp(from_dd, to_dd, operand):
     return Interpolation(from_dd, to_dd, operand)
 
 
-def interleave(operand, dofdesc=None):
-    dofdesc = as_dofdesc(dofdesc)
-    return interp(dofdesc, dofdesc.copy(granularity=GRANULARITY_CENTER), operand)
-
-
 class SingleScalarOperandExpression(Expression):
 
     init_arg_names = ("operand",)

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -1005,8 +1005,7 @@ def _simplex_mapping_max_stretch_factor(ambient_dim, dim=None, dofdesc=None):
     return Max(tuple(stretch_factors))
 
 
-def _hypercube_mapping_max_stretch_factor(ambient_dim, dim=None, dofdesc=None,
-        with_elementwise_max=True):
+def _hypercube_mapping_max_stretch_factor(ambient_dim, dim=None, dofdesc=None):
     if dim is None:
         dim = ambient_dim - 1
 
@@ -1086,8 +1085,7 @@ def _expansion_radii_factor(ambient_dim, dim):
     return 0.5 * dim_fudge_factor
 
 
-def _quad_resolution(ambient_dim, dim=None, granularity=None, dofdesc=None,
-        with_elementwise_max=False):
+def _quad_resolution(ambient_dim, dim=None, granularity=None, dofdesc=None):
     """This measures the quadrature resolution across the
     mesh. In a 1D uniform mesh of uniform 'parametrization speed', it
     should be the same as the element length.
@@ -1103,10 +1101,7 @@ def _quad_resolution(ambient_dim, dim=None, granularity=None, dofdesc=None,
     to_dd = from_dd.copy(granularity=granularity)
 
     stretch = _mapping_max_stretch_factor(ambient_dim, dim=dim, dofdesc=from_dd)
-    if with_elementwise_max:
-        return ElementwiseMax(stretch, to_dd)
-    else:
-        return interp(from_dd, to_dd, stretch)
+    return interp(from_dd, to_dd, stretch)
 
 
 def _source_danger_zone_radii(ambient_dim, dim=None,

--- a/test/test_cost_model.py
+++ b/test/test_cost_model.py
@@ -721,14 +721,17 @@ def test_cost_model_correctness(actx_factory, dim, off_surface,
                 make_uniform_particle_array(queue, ntargets, dim, np.float64))
         target_discrs_and_qbx_sides = ((targets, 0),)
         qbx_forced_limit = None
+
+        places = GeometryCollection((lpot_source, targets))
     else:
-        targets = lpot_source.density_discr
-        target_discrs_and_qbx_sides = ((targets, 1),)
-        qbx_forced_limit = 1
-    places = GeometryCollection((lpot_source, targets))
+        places = GeometryCollection(lpot_source)
 
     source_dd = places.auto_source
     density_discr = places.get_discretization(source_dd.geometry)
+
+    if not off_surface:
+        target_discrs_and_qbx_sides = ((density_discr, 1),)
+        qbx_forced_limit = 1
 
     # Construct bound op, run cost model.
     sigma_sym = sym.var("sigma")

--- a/test/test_global_qbx.py
+++ b/test/test_global_qbx.py
@@ -81,6 +81,8 @@ def iter_elements(discr):
 
 def run_source_refinement_test(actx_factory, mesh, order,
         helmholtz_k=None, surface_name="surface", visualize=False):
+    if visualize:
+        logging.basicConfig(level=logging.INFO)
     actx = actx_factory()
 
     # {{{ initial geometry
@@ -93,7 +95,7 @@ def run_source_refinement_test(actx_factory, mesh, order,
     lpot_source = QBXLayerPotentialSource(discr,
             qbx_order=order,  # not used in refinement
             fine_order=order)
-    places = GeometryCollection(lpot_source)
+    places = GeometryCollection(lpot_source, auto_where="source")
 
     logger.info("nelements: %d", discr.mesh.nelements)
     logger.info("ndofs: %d", discr.ndofs)
@@ -102,15 +104,14 @@ def run_source_refinement_test(actx_factory, mesh, order,
 
     # {{{ refined geometry
 
-    def _visualize_quad_resolution(_places, dd, suffix):
+    def _visualize_quad_resolution(dd, suffix):
         if dd.discr_stage is None:
             vis_discr = lpot_source.density_discr
         else:
-            vis_discr = _places.get_discretization(dd.geometry, dd.discr_stage)
+            vis_discr = places.get_discretization(dd.geometry, dd.discr_stage)
 
-        stretch = bind(_places,
-                sym._simplex_mapping_max_stretch_factor(
-                    _places.ambient_dim, with_elementwise_max=False),
+        stretch = bind(places,
+                sym._simplex_mapping_max_stretch_factor(places.ambient_dim),
                 auto_where=dd)(actx)
 
         from meshmode.discretization.visualization import make_visualizer
@@ -131,9 +132,9 @@ def run_source_refinement_test(actx_factory, mesh, order,
 
     if visualize:
         dd = places.auto_source
-        _visualize_quad_resolution(places, dd.copy(discr_stage=None), "original")
-        _visualize_quad_resolution(places, dd.to_stage1(), "stage1")
-        _visualize_quad_resolution(places, dd.to_stage2(), "stage2")
+        _visualize_quad_resolution(dd.copy(discr_stage=None), "original")
+        _visualize_quad_resolution(dd.to_stage1(), "stage1")
+        _visualize_quad_resolution(dd.to_stage2(), "stage2")
 
     # }}}
 
@@ -163,8 +164,11 @@ def run_source_refinement_test(actx_factory, mesh, order,
 
     source_danger_zone_radii = actx.to_numpy(flatten(
             bind(
-                places,
-                sym._source_danger_zone_radii(ambient_dim, dofdesc=dd.to_stage2())
+                places, sym.ElementwiseMax(
+                    sym._source_danger_zone_radii(
+                        ambient_dim, dofdesc=dd.to_stage2()),
+                    dofdesc=dd.to_stage2().copy(granularity=sym.GRANULARITY_ELEMENT)
+                    )
                 )(actx), actx)
             )
     quad_res = actx.to_numpy(flatten(
@@ -177,7 +181,7 @@ def run_source_refinement_test(actx_factory, mesh, order,
     def check_disk_undisturbed_by_sources(centers_element, sources_element):
         if centers_element.index == sources_element.index:
             # Same element
-            return
+            return True
 
         my_int_centers = int_centers[:, centers_element.discr_slice]
         my_ext_centers = ext_centers[:, centers_element.discr_slice]
@@ -186,20 +190,30 @@ def run_source_refinement_test(actx_factory, mesh, order,
         nodes = stage1_density_nodes[:, sources_element.discr_slice]
 
         # =distance(centers of element 1, element 2)
-        dist = (
-            la.norm((
-                    all_centers[..., np.newaxis]
-                    - nodes[:, np.newaxis, ...]).T,
-                axis=-1)
-            .min())
+        dist = np.min(
+                la.norm(
+                    (all_centers[..., np.newaxis] - nodes[:, np.newaxis, ...]).T,
+                    axis=-1),
+                axis=0)
 
         # Criterion:
         # A center cannot be closer to another element than to its originating
         # element.
 
-        rad = expansion_radii[centers_element.discr_slice]
-        assert np.all(dist >= rad * (1 - expansion_disturbance_tolerance)), (
-                dist, rad, centers_element.index, sources_element.index)
+        rad = (
+                (1 - expansion_disturbance_tolerance)
+                * np.tile(expansion_radii[centers_element.discr_slice], 2))
+
+        is_undisturbed = np.all(dist >= rad)
+        if not is_undisturbed:
+            logger.info("FAILED: centers_element %3d sources_element %3d",
+                    centers_element.index, sources_element.index)
+            logger.info("radius [%s] > %.12e",
+                    ", ".join([f"{r:.12e}" for r in rad]), dist)
+            logger.info("radius [%s]",
+                    ", ".join([f"{str(dist>=r):>18}" for r in rad]))
+
+        return is_undisturbed
 
     def check_sufficient_quadrature_resolution(centers_element, sources_element):
         dz_radius = source_danger_zone_radii[sources_element.index]
@@ -221,20 +235,35 @@ def run_source_refinement_test(actx_factory, mesh, order,
         # Criterion:
         # The quadrature contribution from each element is as accurate
         # as from the center's own source element.
-        assert dist >= dz_radius, \
-                (dist, dz_radius, centers_element.index, sources_element.index)
+
+        is_quadratured = dist >= dz_radius
+        if not is_quadratured:
+            logger.info("FAILED: centers_element %3d sources_element %3d",
+                    centers_element.index, sources_element.index)
+            logger.info("dist %.12e dz_radius %.12e", dist, dz_radius)
+
+        return is_quadratured
 
     def check_quad_res_to_helmholtz_k_ratio(element):
         # Check wavenumber to element size ratio.
-        assert quad_res[element.index] * helmholtz_k <= 5
+        return quad_res[element.index] * helmholtz_k <= 5
 
     for element_1 in iter_elements(stage1_density_discr):
+        success = True
         for element_2 in iter_elements(stage1_density_discr):
-            check_disk_undisturbed_by_sources(element_1, element_2)
+            result = check_disk_undisturbed_by_sources(element_1, element_2)
+            success = success and result
+        assert success, "'check_disk_undisturbed_by_sources' failed"
+
+        success = True
         for element_2 in iter_elements(quad_stage2_density_discr):
-            check_sufficient_quadrature_resolution(element_1, element_2)
+            result = check_sufficient_quadrature_resolution(element_1, element_2)
+            success = success and result
+        assert success, "'check_sufficient_source_quadrature_resolution' failed"
+
         if helmholtz_k is not None:
-            check_quad_res_to_helmholtz_k_ratio(element_1)
+            success = check_quad_res_to_helmholtz_k_ratio(element_1)
+            assert success, "'check_quad_res_to_helmholtz_k_ratio' failed"
 
     # }}}
 
@@ -242,7 +271,7 @@ def run_source_refinement_test(actx_factory, mesh, order,
 
 
 @pytest.mark.parametrize(("curve_name", "curve_f", "nelements"), [
-    ("20-to-1 ellipse", partial(mgen.ellipse, 20), 100),
+    ("20-to-1-ellipse", partial(mgen.ellipse, 20), 100),
     ("horseshoe", horseshoe, 64),
     ])
 def test_source_refinement_2d(actx_factory,
@@ -251,10 +280,8 @@ def test_source_refinement_2d(actx_factory,
     order = 8
 
     mesh = mgen.make_curve_mesh(curve_f, np.linspace(0, 1, nelements+1), order)
-    run_source_refinement_test(actx_factory, mesh, order,
-            helmholtz_k=helmholtz_k,
-            surface_name=curve_name,
-            visualize=visualize)
+    run_source_refinement_test(actx_factory, mesh, order, helmholtz_k,
+                               surface_name=curve_name, visualize=visualize)
 
 
 @pytest.mark.parametrize(("surface_name", "surface_f", "order"), [
@@ -266,8 +293,7 @@ def test_source_refinement_3d(actx_factory,
         surface_name, surface_f, order, visualize=False):
     mesh = surface_f(order=order)
     run_source_refinement_test(actx_factory, mesh, order,
-            surface_name=surface_name,
-            visualize=visualize)
+                               surface_name=surface_name, visualize=visualize)
 
 
 @pytest.mark.parametrize(("curve_name", "curve_f", "nelements"), [

--- a/test/test_global_qbx.py
+++ b/test/test_global_qbx.py
@@ -161,7 +161,6 @@ def run_source_refinement_test(actx_factory, mesh, order,
         bind(places, sym.expansion_radii(ambient_dim))(actx), actx)
         )
 
-    dd = dd.copy(granularity=sym.GRANULARITY_ELEMENT)
     source_danger_zone_radii = actx.to_numpy(flatten(
             bind(
                 places,

--- a/test/test_global_qbx.py
+++ b/test/test_global_qbx.py
@@ -111,7 +111,7 @@ def run_source_refinement_test(actx_factory, mesh, order,
             vis_discr = places.get_discretization(dd.geometry, dd.discr_stage)
 
         stretch = bind(places,
-                sym._simplex_mapping_max_stretch_factor(places.ambient_dim),
+                sym._mapping_max_stretch_factor(places.ambient_dim),
                 auto_where=dd)(actx)
 
         from meshmode.discretization.visualization import make_visualizer
@@ -280,8 +280,10 @@ def test_source_refinement_2d(actx_factory,
     order = 8
 
     mesh = mgen.make_curve_mesh(curve_f, np.linspace(0, 1, nelements+1), order)
-    run_source_refinement_test(actx_factory, mesh, order, helmholtz_k,
-                               surface_name=curve_name, visualize=visualize)
+    run_source_refinement_test(actx_factory, mesh, order,
+            helmholtz_k=helmholtz_k,
+            surface_name=curve_name,
+            visualize=visualize)
 
 
 @pytest.mark.parametrize(("surface_name", "surface_f", "order"), [
@@ -293,7 +295,8 @@ def test_source_refinement_3d(actx_factory,
         surface_name, surface_f, order, visualize=False):
     mesh = surface_f(order=order)
     run_source_refinement_test(actx_factory, mesh, order,
-                               surface_name=surface_name, visualize=visualize)
+            surface_name=surface_name,
+            visualize=visualize)
 
 
 @pytest.mark.parametrize(("curve_name", "curve_f", "nelements"), [


### PR DESCRIPTION
Switched `_quad_resolution` to be per-node instead of per-element. Let's see what breaks!

~~@inducer The first commit is just #46 squashed down.~~