### PR TITLE
Fix scipy intersphinx link

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,7 +19,7 @@ intersphinx_mapping = {
     "https://docs.python.org/3/": None,
     "https://documen.tician.de/boxtree/": None,
     "https://numpy.org/doc/stable/": None,
-    "https://docs.scipy.org/doc/scipy/reference/": None,
+    "https://scipy.github.io/devdocs/": None,
     "https://documen.tician.de/arraycontext/": None,
     "https://documen.tician.de/meshmode/": None,
     "https://documen.tician.de/modepy/": None,


### PR DESCRIPTION
Seems to have moved (?) but couldn't find anything official, so not sure if this is just a temporary redirect because the main site is down for some reason.

https://docs.scipy.org/doc/scipy/reference  