### PR TITLE
Remove usage of MeshElementGroup.element_nr_base

### DIFF
--- a/pytential/qbx/refinement.py
+++ b/pytential/qbx/refinement.py
@@ -524,9 +524,9 @@ def _visualize_refinement(actx: PyOpenCLArrayContext, discr,
     nodes_flags = []
 
     element_nr_base = 0
-    for grp in discr.groups:
+    for igrp, grp in enumerate(discr.groups):
         meg = grp.mesh_el_group
-        nodes_flags_grp = actx.to_numpy(nodes_flags_template[grp.index])
+        nodes_flags_grp = actx.to_numpy(nodes_flags_template[igrp])
         nodes_flags_grp[flags[element_nr_base:element_nr_base + meg.nelements]] = 1
         nodes_flags.append(actx.from_numpy(nodes_flags_grp))
 

--- a/pytential/qbx/refinement.py
+++ b/pytential/qbx/refinement.py
@@ -522,15 +522,17 @@ def _visualize_refinement(actx: PyOpenCLArrayContext, discr,
     flags = flags.astype(bool)
     nodes_flags_template = discr.zeros(actx)
     nodes_flags = []
+
+    element_nr_base = 0
     for grp in discr.groups:
         meg = grp.mesh_el_group
         nodes_flags_grp = actx.to_numpy(nodes_flags_template[grp.index])
-        nodes_flags_grp[
-                flags[meg.element_nr_base:meg.nelements+meg.element_nr_base]] = 1
+        nodes_flags_grp[flags[element_nr_base:element_nr_base + meg.nelements]] = 1
         nodes_flags.append(actx.from_numpy(nodes_flags_grp))
 
-    nodes_flags = DOFArray(actx, tuple(nodes_flags))
+        element_nr_base += meg.nelements
 
+    nodes_flags = DOFArray(actx, tuple(nodes_flags))
     vis_data = [
         ("refine_flags", nodes_flags),
         ]

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -168,10 +168,9 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
         assert operand.shape == (len(discr.groups),)
 
         def _reduce(knl, result):
-            for grp in discr.groups:
-                self.array_context.call_loopy(knl,
-                        operand=operand[grp.index],
-                        result=result[grp.index])
+            for g_operand, g_result in zip(operand, result):
+                self.array_context.call_loopy(
+                    knl, operand=g_operand, result=g_result)
 
             return result
 

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -62,22 +62,6 @@ class EvaluationMapperBoundOpCacheKey:
 
 # {{{ evaluation mapper base (shared, between actual eval and cost model)
 
-def mesh_el_view(mesh, group_nr, global_array):
-    """Return a view of *global_array* of shape
-    ``(..., mesh.groups[group_nr].nelements)``
-    where *global_array* is of shape ``(..., nelements)``,
-    where *nelements* is the global (per-mesh) element count.
-    """
-
-    group = mesh.groups[group_nr]
-
-    return global_array[
-        ..., group.element_nr_base:group.element_nr_base + group.nelements] \
-        .reshape(
-            global_array.shape[:-1]
-            + (group.nelements,))
-
-
 class EvaluationMapperBase(PymbolicEvaluationMapper):
     def __init__(self, bound_expr, actx: PyOpenCLArrayContext, context=None,
             target_geometry=None,


### PR DESCRIPTION
Deprecated in `meshmode` since inducer/meshmode#302.