### PR TITLE
Consistent naming for proxies + skeletonization

### DIFF
--- a/doc/linalg.rst
+++ b/doc/linalg.rst
@@ -1,6 +1,15 @@
 Linear Algebra Routines
 =======================
 
+In the linear algebra parts of :mod:`pytential`, the following naming
+scheme is used:
+
+* ``block`` refers to a piece of a vector operator, e.g. the :math:`S_{xx}`
+  component of the Stokeslet.
+* ``cluster`` refers to a piece of a ``block`` as used by the recursive
+  proxy-based skeletonization of the direct solver algorithms. Clusters
+  are represented by a :class:`~pytential.linalg.TargetAndSourceClusterList`.
+
 Hierarchical Direct Solver
 --------------------------
 

--- a/pytential/linalg/__init__.py
+++ b/pytential/linalg/__init__.py
@@ -21,20 +21,20 @@ THE SOFTWARE.
 """
 
 from pytential.linalg.utils import (
-        BlockIndexRanges, MatrixBlockIndexRanges,
-        make_block_index_from_array, make_index_blockwise_product,
+        IndexList, TargetAndSourceClusterList,
+        make_index_list, make_index_cluster_cartesian_product,
         )
 from pytential.linalg.proxy import (
-        BlockProxyPoints, ProxyGeneratorBase,
-        ProxyGenerator, QBXProxyGenerator,
-        partition_by_nodes, gather_block_neighbor_points,
+        ProxyClusterGeometryData,
+        ProxyGeneratorBase, ProxyGenerator, QBXProxyGenerator,
+        partition_by_nodes, gather_cluster_neighbor_points,
         )
 
 __all__ = (
-    "BlockIndexRanges", "MatrixBlockIndexRanges",
-    "make_block_index_from_array", "make_index_blockwise_product",
+    "IndexList", "TargetAndSourceClusterList",
+    "make_index_list", "make_index_cluster_cartesian_product",
 
-    "BlockProxyPoints", "ProxyGeneratorBase",
-    "ProxyGenerator", "QBXProxyGenerator",
-    "partition_by_nodes", "gather_block_neighbor_points",
+    "ProxyClusterGeometryData",
+    "ProxyGeneratorBase", "ProxyGenerator", "QBXProxyGenerator",
+    "partition_by_nodes", "gather_cluster_neighbor_points",
 )

--- a/test/extra_matrix_data.py
+++ b/test/extra_matrix_data.py
@@ -3,7 +3,6 @@ import numpy as np
 from pytools.obj_array import make_obj_array
 
 from pytential import sym
-from pytential.linalg import MatrixBlockIndexRanges
 
 import extra_int_eq_data as extra
 
@@ -12,7 +11,7 @@ import extra_int_eq_data as extra
 
 class MatrixTestCaseMixin:
     # partitioning
-    approx_block_count = 10
+    approx_cluster_count = 10
     max_particles_in_box = None
     tree_kind = "adaptive-level-restricted"
     index_sparsity_factor = 1.0
@@ -27,27 +26,27 @@ class MatrixTestCaseMixin:
     # disable fmm for matrix tests
     fmm_backend = None
 
-    def get_block_indices(self, actx, places, dofdesc=None):
+    def get_cluster_index(self, actx, places, dofdesc=None):
         if dofdesc is None:
             dofdesc = places.auto_source
-
-        discr = places.get_discretization(dofdesc.geometry, dofdesc.discr_stage)
+        discr = places.get_discretization(dofdesc.geometry)
 
         max_particles_in_box = self.max_particles_in_box
         if max_particles_in_box is None:
-            max_particles_in_box = discr.ndofs // self.approx_block_count
+            max_particles_in_box = discr.ndofs // self.approx_cluster_count
 
         from pytential.linalg import partition_by_nodes
-        indices = partition_by_nodes(actx, places,
+        cindex = partition_by_nodes(actx, places,
                 dofdesc=dofdesc,
                 tree_kind=self.tree_kind,
                 max_particles_in_box=max_particles_in_box)
 
-        # randomly pick a subset of points from each block
+        # randomly pick a subset of points from each cluster
         if abs(self.index_sparsity_factor - 1.0) > 1.0e-14:
-            subset = np.empty(indices.nblocks, dtype=object)
-            for i in range(indices.nblocks):
-                iidx = indices.block_indices(i)
+            subset = np.empty(cindex.nclusters, dtype=object)
+
+            for i in range(cindex.nclusters):
+                iidx = cindex.cluster_indices(i)
                 isize = int(self.index_sparsity_factor * len(iidx))
                 isize = max(1, min(isize, len(iidx)))
 
@@ -55,14 +54,15 @@ class MatrixTestCaseMixin:
                         np.random.choice(iidx, size=isize, replace=False)
                         )
 
-            from pytential.linalg import make_block_index_from_array
-            indices = make_block_index_from_array(subset)
+            from pytential.linalg import make_index_list
+            cindex = make_index_list(subset)
 
-        return indices
+        return cindex
 
-    def get_matrix_block_indices(self, actx, places, dofdesc=None):
-        indices = self.get_block_indices(actx, places, dofdesc=dofdesc)
-        return MatrixBlockIndexRanges(indices, indices)
+    def get_tgt_src_cluster_index(self, actx, places, dofdesc=None):
+        from pytential.linalg import TargetAndSourceClusterList
+        cindex = self.get_cluster_index(actx, places, dofdesc=dofdesc)
+        return TargetAndSourceClusterList(cindex, cindex)
 
     def get_operator(self, ambient_dim, qbx_forced_limit="avg"):
         knl = self.knl_class(ambient_dim)


### PR DESCRIPTION
This renames a bunch of stuff (see https://github.com/inducer/pytential/pull/30#discussion_r846534490) to be more consistent across the board. The basic plan is
* `block` naming is only used when talking about the different pieces of a vector operator.
* `cluster` naming is used by the proxy / skeletonization code.

There's a few things in there that could use some more bikeshedding:
* Renamed `BlockIndexRanges` to `ArrayClusterIndex`: this just holds a tuple of `(indices, ranges)`.
* Renamed `MatrixBlockIndexRanges` to `MatrixClusterIndex`: this just holds `(row, col)` of `ArrayClusterIndex`.
* Renamed `BlockProxyPoints` to `ProxyClusterGeometryData`: this holds the generated proxy information, i.e. points for each cluster, centers, radii and the geometry it was generated from.

There's still the matrix builder things to rename. They're currently called `MatrixBlockBuilderBase`, `NearFieldBlockBuilder` and `FarFieldBlockBuilder`. Not quite sure what a better name would be though..