### PR TITLE
Proxy: reuse TreeBuilder 

### DIFF
--- a/pytential/linalg/proxy.py
+++ b/pytential/linalg/proxy.py
@@ -233,7 +233,7 @@ def make_compute_block_centers_knl(
             end
             """ % dict(insns=insns), [
                 lp.GlobalArg("sources", None,
-                    shape=(ndim, "nsources"), dim_tags="sep,C"),
+                    shape=(ndim, "nsources"), dim_tags="sep,C", offset=lp.auto),
                 lp.ValueArg("nsources", np.int64),
                 ...
                 ],
@@ -413,7 +413,7 @@ def make_compute_block_radii_knl(
             end
             """, [
                 lp.GlobalArg("sources", None,
-                    shape=(ndim, "nsources"), dim_tags="sep,C"),
+                    shape=(ndim, "nsources"), dim_tags="sep,C", offset=lp.auto),
                 lp.ValueArg("nsources", np.int64),
                 lp.ValueArg("radius_factor", np.float64),
                 ...
@@ -471,11 +471,11 @@ def make_compute_block_qbx_radii_knl(
             end
             """, [
                 lp.GlobalArg("sources", None,
-                    shape=(ndim, "nsources"), dim_tags="sep,C"),
+                    shape=(ndim, "nsources"), dim_tags="sep,C", offset=lp.auto),
                 lp.GlobalArg("center_int", None,
-                    shape=(ndim, "nsources"), dim_tags="sep,C"),
+                    shape=(ndim, "nsources"), dim_tags="sep,C", offset=lp.auto),
                 lp.GlobalArg("center_ext", None,
-                    shape=(ndim, "nsources"), dim_tags="sep,C"),
+                    shape=(ndim, "nsources"), dim_tags="sep,C", offset=lp.auto),
                 lp.ValueArg("nsources", np.int64),
                 lp.ValueArg("radius_factor", np.float64),
                 ...

--- a/pytential/linalg/proxy.py
+++ b/pytential/linalg/proxy.py
@@ -53,6 +53,9 @@ Proxy Point Generation
 .. autofunction:: gather_block_neighbor_points
 """
 
+# FIXME: this is just an arbitrary value
+_DEFAULT_MAX_PARTICLES_IN_BOX = 32
+
 
 # {{{ point index partitioning
 
@@ -69,8 +72,7 @@ def partition_by_nodes(
     """
 
     if max_particles_in_box is None:
-        # FIXME: this is just an arbitrary value
-        max_particles_in_box = 32
+        max_particles_in_box = _DEFAULT_MAX_PARTICLES_IN_BOX
 
     if tree_kind is not None:
         from boxtree import box_flags_enum
@@ -531,8 +533,7 @@ def gather_block_neighbor_points(
     """
 
     if max_particles_in_box is None:
-        # FIXME: this is a fairly arbitrary value
-        max_particles_in_box = 32
+        max_particles_in_box = _DEFAULT_MAX_PARTICLES_IN_BOX
 
     # {{{ get only sources in indices
 

--- a/pytential/qbx/utils.py
+++ b/pytential/qbx/utils.py
@@ -86,6 +86,11 @@ class TreeCodeContainer:
         from boxtree.tree import ParticleListFilter
         return ParticleListFilter(self.array_context.context)
 
+    @memoize_method
+    def build_area_query(self):
+        from boxtree.area_query import AreaQueryBuilder
+        return AreaQueryBuilder(self.array_context.context)
+
 # }}}
 
 

--- a/test/test_linalg_proxy.py
+++ b/test/test_linalg_proxy.py
@@ -213,7 +213,7 @@ def test_partition_points(actx_factory, tree_kind, case, visualize=False):
     places = GeometryCollection(qbx, auto_where=case.name)
 
     density_discr = places.get_discretization(case.name)
-    indices = case.get_block_indices(actx, density_discr, matrix_indices=False)
+    indices = case.get_block_indices(actx, places)
 
     expected_indices = np.arange(0, density_discr.ndofs)
     assert indices.ranges[-1] == density_discr.ndofs
@@ -259,7 +259,7 @@ def test_proxy_generator(actx_factory, case,
     places = GeometryCollection(qbx, auto_where=case.name)
 
     density_discr = places.get_discretization(case.name)
-    srcindices = case.get_block_indices(actx, density_discr, matrix_indices=False)
+    srcindices = case.get_block_indices(actx, places)
 
     generator = proxy_generator_cls(places,
             approx_nproxy=case.proxy_approx_count,
@@ -328,7 +328,7 @@ def test_neighbor_points(actx_factory, case,
     places = GeometryCollection(qbx, auto_where=case.name)
 
     density_discr = places.get_discretization(case.name)
-    srcindices = case.get_block_indices(actx, density_discr, matrix_indices=False)
+    srcindices = case.get_block_indices(actx, places)
 
     # generate proxy points
     generator = proxy_generator_cls(places,
@@ -338,7 +338,7 @@ def test_neighbor_points(actx_factory, case,
 
     # get neighboring points
     from pytential.linalg import gather_block_neighbor_points
-    nbrindices = gather_block_neighbor_points(actx, density_discr, pxy)
+    nbrindices = gather_block_neighbor_points(actx, pxy)
 
     pxy = pxy.to_numpy(actx)
     pxycenters = np.stack(pxy.centers)


### PR DESCRIPTION
Main changes are
* use `QBXLayerPotentialSource.tree_code_container.build_tree` if available when gathering neighbors and partitioning things.
* add a `build_area_query()` to `tree_code_container` and reuse that as well.

The rest of it is just moving some things around to make sure that everyone has proper access to the geometry collection and the `QBXLayerPotentialSource` when needed. 