### PR TITLE
Make code containers functions instead of methods

### DIFF
--- a/pytential/collection.py
+++ b/pytential/collection.py
@@ -274,12 +274,12 @@ class GeometryCollection:
         except KeyError:
             dofdesc = sym.DOFDescriptor(geometry, discr_stage)
 
+            from pytential.qbx.refinement import refiner_code_container
+            wrangler = refiner_code_container(lpot_source._setup_actx).get_wrangler()
+
             from pytential.qbx.refinement import _refine_for_global_qbx
             # NOTE: this adds the required discretizations to the cache
-            _refine_for_global_qbx(self, dofdesc,
-                    lpot_source.refiner_code_container.get_wrangler(),
-                    _copy_collection=False)
-
+            _refine_for_global_qbx(self, dofdesc, wrangler, _copy_collection=False)
             discr = self._get_discr_from_cache(geometry, discr_stage)
 
         return discr

--- a/pytential/linalg/proxy.py
+++ b/pytential/linalg/proxy.py
@@ -86,9 +86,11 @@ def partition_by_nodes(
     discr = places.get_discretization(dofdesc.geometry, dofdesc.discr_stage)
 
     if tree_kind is not None:
+        from pytential.qbx.utils import tree_code_container
+        tcc = tree_code_container(lpot_source._setup_actx)
+
         from arraycontext import thaw
-        builder = lpot_source.tree_code_container.build_tree()
-        tree, _ = builder(actx.queue,
+        tree, _ = tcc.build_tree()(actx.queue,
                 particles=flatten(
                     thaw(discr.nodes(), actx), actx, leaf_class=DOFArray
                     ),
@@ -594,12 +596,12 @@ def gather_cluster_neighbor_points(
 
     # {{{ perform area query
 
-    builder = lpot_source.tree_code_container.build_tree()
-    tree, _ = builder(actx.queue, sources,
-            max_particles_in_box=max_particles_in_box)
+    from pytential.qbx.utils import tree_code_container
+    tcc = tree_code_container(lpot_source._setup_actx)
 
-    builder = lpot_source.tree_code_container.build_area_query()
-    query, _ = builder(actx.queue, tree, pxy.centers, pxy.radii)
+    tree, _ = tcc.build_tree()(actx.queue, sources,
+            max_particles_in_box=max_particles_in_box)
+    query, _ = tcc.build_area_query()(actx.queue, tree, pxy.centers, pxy.radii)
 
     tree = tree.get(actx.queue)
     query = query.get(actx.queue)

--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -341,60 +341,6 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
 
     # }}}
 
-    # {{{ code containers
-
-    @property
-    def tree_code_container(self):
-        @memoize_in(self._setup_actx, (
-                QBXLayerPotentialSource, "tree_code_container"))
-        def make_container():
-            from pytential.qbx.utils import TreeCodeContainer
-            return TreeCodeContainer(self._setup_actx)
-
-        return make_container()
-
-    @property
-    def refiner_code_container(self):
-        @memoize_in(self._setup_actx, (
-                QBXLayerPotentialSource, "refiner_code_container"))
-        def make_container():
-            from pytential.qbx.refinement import RefinerCodeContainer
-            return RefinerCodeContainer(
-                    self._setup_actx, self.tree_code_container)
-
-        return make_container()
-
-    @property
-    def target_association_code_container(self):
-        @memoize_in(self._setup_actx, (
-                QBXLayerPotentialSource, "target_association_code_container"))
-        def make_container():
-            from pytential.qbx.target_assoc import TargetAssociationCodeContainer
-            return TargetAssociationCodeContainer(
-                    self._setup_actx, self.tree_code_container)
-
-        return make_container()
-
-    @property
-    def qbx_fmm_geometry_data_code_container(self):
-        @memoize_in(self._setup_actx, (
-                QBXLayerPotentialSource, "qbx_fmm_geometry_data_code_container"))
-        def make_container(
-                debug, ambient_dim, well_sep_is_n_away,
-                from_sep_smaller_crit):
-            from pytential.qbx.geometry import QBXFMMGeometryDataCodeContainer
-            return QBXFMMGeometryDataCodeContainer(
-                    self._setup_actx,
-                    ambient_dim, self.tree_code_container, debug,
-                    _well_sep_is_n_away=well_sep_is_n_away,
-                    _from_sep_smaller_crit=from_sep_smaller_crit)
-
-        return make_container(
-                self.debug, self.ambient_dim,
-                self._well_sep_is_n_away, self._from_sep_smaller_crit)
-
-    # }}}
-
     # {{{ internal API
 
     @memoize_method
@@ -409,11 +355,16 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
             :class:`pytential.target.TargetBase`
             instance
         """
-        from pytential.qbx.geometry import QBXFMMGeometryData
+        from pytential.qbx.geometry import qbx_fmm_geometry_data_code_container
+        code_container = qbx_fmm_geometry_data_code_container(
+                self._setup_actx, self.ambient_dim,
+                debug=self.debug,
+                well_sep_is_n_away=self._well_sep_is_n_away,
+                from_sep_smaller_crit=self._from_sep_smaller_crit)
 
-        return QBXFMMGeometryData(places, name,
-                self.qbx_fmm_geometry_data_code_container,
-                target_discrs_and_qbx_sides,
+        from pytential.qbx.geometry import QBXFMMGeometryData
+        return QBXFMMGeometryData(
+                places, name, code_container, target_discrs_and_qbx_sides,
                 target_association_tolerance=self.target_association_tolerance,
                 tree_kind=self._tree_kind,
                 debug=self.debug)

--- a/pytential/qbx/utils.py
+++ b/pytential/qbx/utils.py
@@ -24,7 +24,7 @@ THE SOFTWARE.
 
 import numpy as np
 
-from pytools import memoize_method, log_process
+from pytools import memoize_method, memoize_in, log_process
 from arraycontext import PyOpenCLArrayContext
 from meshmode.dof_array import DOFArray
 
@@ -91,6 +91,14 @@ class TreeCodeContainer:
         from boxtree.area_query import AreaQueryBuilder
         return AreaQueryBuilder(self.array_context.context)
 
+
+def tree_code_container(actx: PyOpenCLArrayContext) -> TreeCodeContainer:
+    @memoize_in(actx, (TreeCodeContainer, tree_code_container))
+    def make_container():
+        return TreeCodeContainer(actx)
+
+    return make_container()
+
 # }}}
 
 
@@ -109,6 +117,7 @@ class TreeCodeContainerMixin:
 
     def particle_list_filter(self):
         return self.tree_code_container.particle_list_filter()
+
 
 # }}}
 

--- a/test/test_global_qbx.py
+++ b/test/test_global_qbx.py
@@ -401,11 +401,8 @@ def test_target_association(actx_factory, curve_name, curve_f, nelements,
     # {{{ run target associator and check
 
     from pytential.qbx.target_assoc import (
-            TargetAssociationCodeContainer, associate_targets_to_qbx_centers)
-
-    from pytential.qbx.utils import TreeCodeContainer
-    code_container = TargetAssociationCodeContainer(
-            actx, TreeCodeContainer(actx))
+            target_association_code_container, associate_targets_to_qbx_centers)
+    code_container = target_association_code_container(actx)
 
     target_assoc = (
             associate_targets_to_qbx_centers(
@@ -543,13 +540,9 @@ def test_target_association_failure(actx_factory):
         )
 
     from pytential.qbx.target_assoc import (
-            TargetAssociationCodeContainer, associate_targets_to_qbx_centers,
+            target_association_code_container, associate_targets_to_qbx_centers,
             QBXTargetAssociationFailedException)
-
-    from pytential.qbx.utils import TreeCodeContainer
-
-    code_container = TargetAssociationCodeContainer(
-            actx, TreeCodeContainer(actx))
+    code_container = target_association_code_container(actx)
 
     with pytest.raises(QBXTargetAssociationFailedException):
         associate_targets_to_qbx_centers(


### PR DESCRIPTION
How does this look? It moves each code container from `QBXLayerPotentialSource`, e.g. `refiner_code_container` goes to `pytential.qbx.refinement` as a little function.

Fixes #145.