### PR TITLE
Conda test env: Limit libtiff to <4.4 to work around breakage

### DIFF
--- a/.test-conda-env-py3.yml
+++ b/.test-conda-env-py3.yml
@@ -23,3 +23,6 @@ dependencies:
 - cython
 - gmsh
 - pyvkfft
+
+# https://github.com/conda-forge/libtiff-feedstock/issues/78
+- libtiff<4.4


### PR DESCRIPTION
See https://github.com/conda-forge/libtiff-feedstock/issues/78. Also broken on Github CI.