### PR TITLE
Cache the TranslationClassesBuilder

### DIFF
--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -643,7 +643,9 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
                         self.qbx_order,
                         self.fmm_level_to_order,
                         source_extra_kwargs=source_extra_kwargs,
-                        kernel_extra_kwargs=kernel_extra_kwargs)
+                        kernel_extra_kwargs=kernel_extra_kwargs,
+                        _use_target_specific_qbx=self._use_target_specific_qbx,
+                        )
 
         from pytential.qbx.geometry import target_state
         if actx.to_numpy(actx.np.any(


### PR DESCRIPTION
Takes the construction from https://github.com/inducer/sumpy/blob/3d2a57aadc55c57c457fdb26ed1e28410ee2f54c/sumpy/fmm.py#L325-L331 and puts it in here for caching in the array context (like all the other builders / code containers around).