### PR TITLE
Add an assert that 2*something didn't change dtype in QBX tree

### DIFF
--- a/pytential/qbx/utils.py
+++ b/pytential/qbx/utils.py
@@ -382,6 +382,9 @@ def build_tree_with_qbx_metadata(actx: PyOpenCLArrayContext,
             2 * qbx_element_to_source_starts
             if not use_stage2_discr
             else None)
+    if qbx_element_to_center_starts is not None:
+        assert (qbx_element_to_center_starts.dtype
+                == qbx_element_to_source_starts.dtype)
 
     # Transfer all tree attributes.
     tree_attrs = {}


### PR DESCRIPTION
This adds an assert to catch the specific pyopencl thing that is getting unbroken by https://github.com/inducer/pyopencl/pull/609.

- [x] Clearly, this is expected to fail until https://github.com/inducer/pyopencl/pull/609 is in.