### PR TITLE
Add pyproject and cython build dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42.0.0", "wheel>=0.34.2", "cython>=0.25"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Currently the `cython` dep doesn't seem to be declared anywhere (?).