### PR TITLE
Make temporaries in OperatorCompiler

### DIFF
--- a/pytential/symbolic/compiler.py
+++ b/pytential/symbolic/compiler.py
@@ -598,8 +598,7 @@ class OperatorCompiler(CachedIdentityMapper):
                 # treat them specially. They get assigned to their
                 # own variable by default, which would mean the
                 # CSE prefix would be omitted.
-
-                rec_child = self.rec(expr.child, name_hint=expr.prefix)
+                rec_child = self.map_int_g(expr.child, name_hint=expr.prefix)
             else:
                 rec_child = self.rec(expr.child)
 

--- a/pytential/symbolic/compiler.py
+++ b/pytential/symbolic/compiler.py
@@ -33,8 +33,7 @@ from sumpy.kernel import Kernel
 
 from pytential.symbolic.primitives import (
         DOFDescriptor, IntG, NamedIntermediateResult)
-from pytential.symbolic.mappers import (CachedIdentityMapper, IdentityMapper,
-        DependencyMapper)
+from pytential.symbolic.mappers import CachedIdentityMapper, DependencyMapper
 
 
 # {{{ statements
@@ -572,7 +571,6 @@ class OperatorCompiler(CachedIdentityMapper):
             result = type(expr)((result, self.rec(child)))
             result = self.assign_to_new_var(result)
         return result
-
 
     def map_numpy_array(self, expr):
         # create temporaries so that the scheduler can optimize

--- a/pytential/symbolic/compiler.py
+++ b/pytential/symbolic/compiler.py
@@ -33,7 +33,8 @@ from sumpy.kernel import Kernel
 
 from pytential.symbolic.primitives import (
         DOFDescriptor, IntG, NamedIntermediateResult)
-from pytential.symbolic.mappers import IdentityMapper, DependencyMapper
+from pytential.symbolic.mappers import (CachedIdentityMapper, IdentityMapper,
+        DependencyMapper)
 
 
 # {{{ statements
@@ -452,7 +453,7 @@ def _compute_schedule(
 
 # {{{ compiler
 
-class OperatorCompiler(IdentityMapper):
+class OperatorCompiler(CachedIdentityMapper):
     def __init__(
             self,
             places,
@@ -502,10 +503,6 @@ class OperatorCompiler(IdentityMapper):
 
         result = super().__call__(expr)
 
-        # Put the toplevel expressions into variables as well.
-
-        from pytools.obj_array import obj_array_vectorize
-        result = obj_array_vectorize(self.assign_to_new_var, result)
         inputs, schedule = _compute_schedule(self.dep_mapper, self.code, result)
         return Code(inputs, schedule, result)
 
@@ -566,6 +563,24 @@ class OperatorCompiler(IdentityMapper):
     # }}}
 
     # {{{ map_xxx routines
+
+    def map_sum(self, expr):
+        # create temporaries so that the scheduler can optimize
+        # the life-time of the dependencies
+        result = self.assign_to_new_var(self.rec(expr.children[0]))
+        for child in expr.children[1:]:
+            result = type(expr)((result, self.rec(child)))
+            result = self.assign_to_new_var(result)
+        return result
+
+
+    def map_numpy_array(self, expr):
+        # create temporaries so that the scheduler can optimize
+        # the life-time of the dependencies
+        result = np.empty(expr.shape, dtype=object)
+        for i in np.ndindex(expr.shape):
+            result[i] = self.assign_to_new_var(self.rec(expr[i]))
+        return result
 
     def map_common_subexpression(self, expr):
         # NOTE: EXPRESSION and DISCRETIZATION scopes are handled in

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -27,6 +27,7 @@ from pymbolic.mapper.stringifier import (
         PREC_NONE, PREC_PRODUCT)
 from pymbolic.mapper import (
         Mapper,
+        CachedMapper,
         CSECachingMapperMixin
         )
 from pymbolic.mapper.dependency import (
@@ -138,6 +139,18 @@ class IdentityMapper(IdentityMapperBase):
             return expr
 
         return type(expr)(expr.from_dd, expr.to_dd, operand)
+
+
+class CachedIdentityMapper(CachedMapper, IdentityMapper):
+    def __call__(self, expr):
+        try:
+            return CachedMapper.__call__(self, expr)
+        except TypeError:
+            # Fallback to no cached behaviour for unhashable types
+            # like list, numpy.array
+            return IdentityMapper.__call__(self, expr)
+
+    rec = __call__
 
 # }}}
 


### PR DESCRIPTION
So that the scheduler can manage the life-time of the dependencies better.

For eg:
```
a = IntG0
b = IntG1
c = IntG2
res = a + b + c
```
is written as
```
a = IntG0
b = IntG1
temp = a + b
c = IntG2
res = temp +c
```
First plan needs all of `a, b, c` to be alive at the same moment, but the second plan does not.