### PR TITLE
Remove redundant `to_numpy` on `h_max in test_pec_mfie_extinction`

### DIFF
--- a/test/test_maxwell.py
+++ b/test/test_maxwell.py
@@ -406,8 +406,7 @@ def test_pec_mfie_extinction(actx_factory, case,
                     calc_patch, pde_test_repr.e, pde_test_repr.h, case.k)]
         print("Maxwell residuals:", maxwell_residuals)
 
-        eoc_rec_repr_maxwell.add_data_point(
-                actx.to_numpy(h_max), max(maxwell_residuals))
+        eoc_rec_repr_maxwell.add_data_point(h_max, max(maxwell_residuals))
 
         # }}}
 


### PR DESCRIPTION
To fix this failure:

```
_ test_pec_mfie_extinction[<PyOpenCLArrayContext for <pyopencl.Device 'pthread-Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz' on 'Portable Computing Language'>>-case0] _
[gw1] linux -- Python 3.11.3 /var/lib/gitlab-runner/builds/zCL2egrE/3/inducer/pytential/.miniforge3/envs/testing/bin/python3
Traceback (most recent call last):
  File "/var/lib/gitlab-runner/builds/zCL2egrE/3/inducer/pytential/.miniforge3/envs/testing/lib/python3.11/site-packages/arraycontext/container/traversal.py", line 104, in rec
    iterable = serialize_container(_ary)
               ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/gitlab-runner/builds/zCL2egrE/3/inducer/pytential/.miniforge3/envs/testing/lib/python3.11/functools.py", line 909, in wrapper
    return dispatch(args[0].__class__)(*args, **kw)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/gitlab-runner/builds/zCL2egrE/3/inducer/pytential/.miniforge3/envs/testing/lib/python3.11/site-packages/arraycontext/container/__init__.py", line 243, in _serialize_ndarray_container
    raise NotAnArrayContainerError(
arraycontext.container.NotAnArrayContainerError: cannot serialize 'ndarray' with dtype 'float64'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/var/lib/gitlab-runner/builds/zCL2egrE/3/inducer/pytential/test/test_maxwell.py", line 410, in test_pec_mfie_extinction
    actx.to_numpy(h_max), max(maxwell_residuals))
    ^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/gitlab-runner/builds/zCL2egrE/3/inducer/pytential/.miniforge3/envs/testing/lib/python3.11/site-packages/arraycontext/impl/pyopencl/__init__.py", line 241, in to_numpy
    self._rec_map_container(_to_numpy, array),
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/gitlab-runner/builds/zCL2egrE/3/inducer/pytential/.miniforge3/envs/testing/lib/python3.11/site-packages/arraycontext/impl/pyopencl/__init__.py", line 187, in _rec_map_container
    return rec_map_array_container(_wrapper, array)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/gitlab-runner/builds/zCL2egrE/3/inducer/pytential/.miniforge3/envs/testing/lib/python3.11/site-packages/arraycontext/container/traversal.py", line 305, in rec_map_array_container
    return _map_array_container_impl(f, ary, leaf_cls=leaf_class, recursive=True)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/lib/gitlab-runner/builds/zCL2egrE/3/inducer/pytential/.miniforge3/envs/testing/lib/python3.11/site-packages/arraycontext/container/traversal.py", line 113, in _map_array_container_impl
    return rec(ary)
           ^^^^^^^^
  File "/var/lib/gitlab-runner/builds/zCL2egrE/3/inducer/pytential/.miniforge3/envs/testing/lib/python3.11/site-packages/arraycontext/container/traversal.py", line 106, in rec
    return f(_ary)
           ^^^^^^^
  File "/var/lib/gitlab-runner/builds/zCL2egrE/3/inducer/pytential/.miniforge3/envs/testing/lib/python3.11/site-packages/arraycontext/impl/pyopencl/__init__.py", line 182, in _wrapper
    raise TypeError(
TypeError: PyOpenCLArrayContext.to_numpy invoked with an unsupported array type: got 'ndarray', but expected one of (<class 'arraycontext.impl.pyopencl.taggable_cl_array.TaggableCLArray'>,)
```

See https://gitlab.tiker.net/inducer/pytential/-/jobs/559888 (a scheduled weekly run for slow tests)