### PR TITLE
Mitigate (?) memory growth in tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ pytential/_git_rev.py
 
 *.so
 pytential/qbx/target_specific/impl.c
+
+mprofile_*.dat
+memray-*.bin
+memray-*.html

--- a/pytential/qbx/direct.py
+++ b/pytential/qbx/direct.py
@@ -109,7 +109,7 @@ class LayerPotentialOnTargetAndCenterSubset(LayerPotentialBase):
     def __call__(self, queue, targets, sources, centers, strengths, expansion_radii,
             **kwargs):
         from sumpy.tools import is_obj_array_like
-        knl = self.get_cached_optimized_kernel(
+        knl = self.get_cached_kernel_executor(
                 targets_is_obj_array=is_obj_array_like(targets),
                 sources_is_obj_array=is_obj_array_like(sources),
                 centers_is_obj_array=is_obj_array_like(centers))

--- a/pytential/qbx/geometry.py
+++ b/pytential/qbx/geometry.py
@@ -137,7 +137,8 @@ class QBXFMMGeometryDataCodeContainer(TreeCodeContainerMixin):
         knl = lp.tag_array_axes(knl, "points", "sep, C")
 
         knl = lp.tag_array_axes(knl, "targets", "stride:auto, stride:1")
-        return lp.tag_inames(knl, {"dim": "ilp"})
+        knl = lp.tag_inames(knl, {"dim": "ilp"})
+        return knl.executor(self._setup_actx.context)
 
     @property
     @memoize_method
@@ -192,7 +193,7 @@ class QBXFMMGeometryDataCodeContainer(TreeCodeContainerMixin):
         knl = lp.split_iname(knl, "ibox", 128,
                 inner_tag="l.0", outer_tag="g.0")
 
-        return knl
+        return knl.executor(self._setup_actx.context)
 
     @property
     @memoize_method
@@ -253,7 +254,7 @@ class QBXFMMGeometryDataCodeContainer(TreeCodeContainerMixin):
             lang_version=MOST_RECENT_LANGUAGE_VERSION)
 
         knl = lp.split_iname(knl, "i", 128, inner_tag="l.0", outer_tag="g.0")
-        return knl
+        return knl.executor(self._setup_actx.context)
 
     @property
     @memoize_method

--- a/pytential/qbx/interactions.py
+++ b/pytential/qbx/interactions.py
@@ -153,7 +153,7 @@ class P2QBXLFromCSR(P2EBase):
         qbx_centers = kwargs.pop("qbx_centers")
 
         from sumpy.tools import is_obj_array_like
-        return self.get_cached_optimized_kernel(
+        return self.get_cached_kernel_executor(
                 is_sources_obj_array=is_obj_array_like(sources),
                 is_centers_obj_array=is_obj_array_like(qbx_centers),
                 )(queue, sources=sources, qbx_centers=qbx_centers, **kwargs)
@@ -272,7 +272,7 @@ class M2QBXL(E2EBase):
 
         from sumpy.tools import is_obj_array_like
         qbx_centers = kwargs.pop("qbx_centers")
-        return self.get_cached_optimized_kernel(
+        return self.get_cached_kernel_executor(
                 is_centers_obj_array=is_obj_array_like(qbx_centers),
                 )(queue, centers=centers,
                         qbx_centers=qbx_centers,
@@ -382,7 +382,7 @@ class L2QBXL(E2EBase):
 
         from sumpy.tools import is_obj_array_like
         qbx_centers = kwargs.pop("qbx_centers")
-        return self.get_cached_optimized_kernel(
+        return self.get_cached_kernel_executor(
                 is_centers_obj_array=is_obj_array_like(qbx_centers),
                 )(queue, centers=centers,
                         qbx_centers=qbx_centers,
@@ -499,7 +499,7 @@ class QBXL2P(E2PBase):
         qbx_centers = kwargs.pop("qbx_centers")
 
         from sumpy.tools import is_obj_array_like
-        return self.get_cached_optimized_kernel(
+        return self.get_cached_kernel_executor(
                 is_targets_obj_array=is_obj_array_like(targets),
                 is_centers_obj_array=is_obj_array_like(qbx_centers),
                 )(queue, targets=targets, qbx_centers=qbx_centers, **kwargs)

--- a/pytential/unregularized.py
+++ b/pytential/unregularized.py
@@ -331,7 +331,9 @@ class _FMMGeometryDataCodeContainer:
         knl = lp.tag_array_axes(knl, "points", "sep, C")
 
         knl = lp.tag_array_axes(knl, "targets", "stride:auto, stride:1")
-        return lp.tag_inames(knl, {"dim": "ilp"})
+        knl = lp.tag_inames(knl, {"dim": "ilp"})
+
+        return knl.executor(self.cl_context)
 
     @property
     @memoize_method

--- a/pytential/utils.py
+++ b/pytential/utils.py
@@ -1,5 +1,6 @@
 __copyright__ = """
 Copyright (C) 2020 Matt Wala
+Copyright (C) 2023 University of Illinois Board of Trustees
 """
 
 __license__ = """
@@ -22,6 +23,8 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+import sys
+
 
 def sort_arrays_together(*arys, key=None):
     """Sort a sequence of arrays by considering them
@@ -31,5 +34,28 @@ def sort_arrays_together(*arys, key=None):
                 and returns a value to compare.
     """
     return zip(*sorted(zip(*arys), key=key))
+
+
+def pytest_teardown_function():
+    from pyopencl.tools import clear_first_arg_caches
+    clear_first_arg_caches()
+
+    from sympy.core.cache import clear_cache
+    clear_cache()
+
+    import sumpy
+    sumpy.code_cache.clear_in_mem_cache()
+
+    from loopy import clear_in_mem_caches
+    clear_in_mem_caches()
+
+    import gc
+    gc.collect()
+
+    if sys.platform.startswith("linux"):
+        import ctypes
+        libc = ctypes.CDLL("libc.so.6")
+        libc.malloc_trim(0)
+
 
 # vim: foldmethod=marker

--- a/test/test_beltrami.py
+++ b/test/test_beltrami.py
@@ -38,6 +38,9 @@ import extra_int_eq_data as eid
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])

--- a/test/test_cost_model.py
+++ b/test/test_cost_model.py
@@ -36,13 +36,15 @@ from pytential.qbx import QBXLayerPotentialSource
 from pytential.qbx.cost import (
     QBXCostModel, _PythonQBXCostModel, make_pde_aware_translation_cost_model
 )
-
 from meshmode import _acf           # noqa: F401
 from arraycontext import pytest_generate_tests_for_array_contexts
 from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 
 import logging
 logger = logging.getLogger(__name__)
+
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
 
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,

--- a/test/test_global_qbx.py
+++ b/test/test_global_qbx.py
@@ -45,6 +45,9 @@ from extra_int_eq_data import QuadSpheroidTestCase
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])

--- a/test/test_layer_pot.py
+++ b/test/test_layer_pot.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 __copyright__ = "Copyright (C) 2013 Andreas Kloeckner"
 
 __license__ = """
@@ -37,6 +39,9 @@ from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 
 import logging
 logger = logging.getLogger(__name__)
+
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
 
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
@@ -81,10 +86,6 @@ def test_off_surface_eval(actx_factory, use_fmm, visualize=False):
     logging.basicConfig(level=logging.INFO)
 
     actx = actx_factory()
-
-    # prevent cache 'splosion
-    from sympy.core.cache import clear_cache
-    clear_cache()
 
     nelements = 30
     target_order = 8
@@ -148,10 +149,6 @@ def test_off_surface_eval_vs_direct(actx_factory,  do_plot=False):
     logging.basicConfig(level=logging.INFO)
 
     actx = actx_factory()
-
-    # prevent cache 'splosion
-    from sympy.core.cache import clear_cache
-    clear_cache()
 
     nelements = 300
     target_order = 8
@@ -234,10 +231,6 @@ def test_single_plus_double_with_single_fmm(actx_factory,  do_plot=False):
     logging.basicConfig(level=logging.INFO)
 
     actx = actx_factory()
-
-    # prevent cache 'splosion
-    from sympy.core.cache import clear_cache
-    clear_cache()
 
     nelements = 300
     target_order = 8

--- a/test/test_layer_pot.py
+++ b/test/test_layer_pot.py
@@ -292,7 +292,6 @@ def test_single_plus_double_with_single_fmm(actx_factory,  do_plot=False):
 
     fmm_sigma = fmm_density_discr.zeros(actx) + 1
     fmm_bound_op = bind(places, op, auto_where=("fmm_qbx", "target"))
-    print(fmm_bound_op.code)
     fmm_fld_in_vol = fmm_bound_op(actx, sigma=fmm_sigma)
 
     err = actx.np.fabs(fmm_fld_in_vol - direct_fld_in_vol)

--- a/test/test_layer_pot.py
+++ b/test/test_layer_pot.py
@@ -138,7 +138,7 @@ def test_off_surface_eval(actx_factory, use_fmm, visualize=False):
         pt.colorbar()
         pt.show()
 
-    assert linf_err < 1e-3
+    assert linf_err < 2e-3
 
 # }}}
 

--- a/test/test_layer_pot_eigenvalues.py
+++ b/test/test_layer_pot_eigenvalues.py
@@ -37,6 +37,9 @@ from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])

--- a/test/test_layer_pot_identity.py
+++ b/test/test_layer_pot_identity.py
@@ -39,6 +39,9 @@ import extra_int_eq_data as ied
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])
@@ -233,10 +236,6 @@ def test_identity_convergence(actx_factory,  case, visualize=False):
     case.check()
 
     actx = actx_factory()
-
-    # prevent cache 'splosion
-    from sympy.core.cache import clear_cache
-    clear_cache()
 
     target_order = 8
 

--- a/test/test_linalg_proxy.py
+++ b/test/test_linalg_proxy.py
@@ -40,6 +40,9 @@ import extra_matrix_data as extra
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])

--- a/test/test_linalg_skeletonization.py
+++ b/test/test_linalg_skeletonization.py
@@ -40,6 +40,9 @@ import extra_matrix_data as extra
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])

--- a/test/test_linalg_utils.py
+++ b/test/test_linalg_utils.py
@@ -32,6 +32,9 @@ from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])

--- a/test/test_matrix.py
+++ b/test/test_matrix.py
@@ -43,6 +43,9 @@ import extra_matrix_data as extra
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])
@@ -75,10 +78,6 @@ def test_build_matrix(actx_factory, k, curve_fn, op_type, visualize=False):
     """
 
     actx = actx_factory()
-
-    # prevent cache 'splosion
-    from sympy.core.cache import clear_cache
-    clear_cache()
 
     case = extra.CurveTestCase(
             name="curve",
@@ -196,10 +195,6 @@ def test_build_matrix_conditioning(actx_factory, side, op_type, visualize=False)
 
     actx = actx_factory()
 
-    # prevent cache explosion
-    from sympy.core.cache import clear_cache
-    clear_cache()
-
     case = extra.CurveTestCase(
             name="ellipse",
             curve_fn=lambda t: ellipse(3.0, t),
@@ -305,10 +300,6 @@ def test_cluster_builder(actx_factory, ambient_dim,
     """Test that cluster builders and full matrix builders actually match."""
 
     actx = actx_factory()
-
-    # prevent cache explosion
-    from sympy.core.cache import clear_cache
-    clear_cache()
 
     if ambient_dim == 2:
         case = extra.CurveTestCase(
@@ -424,10 +415,6 @@ def test_build_matrix_fixed_stage(actx_factory,
     """Checks that the block builders match for difference stages."""
 
     actx = actx_factory()
-
-    # prevent cache explosion
-    from sympy.core.cache import clear_cache
-    clear_cache()
 
     case = extra.CurveTestCase(
             name="starfish",

--- a/test/test_maxwell.py
+++ b/test/test_maxwell.py
@@ -39,6 +39,9 @@ from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])

--- a/test/test_scalar_int_eq.py
+++ b/test/test_scalar_int_eq.py
@@ -42,6 +42,9 @@ import extra_int_eq_data as inteq
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])
@@ -476,10 +479,6 @@ def test_integral_equation(actx_factory, case, visualize=False):
     logging.basicConfig(level=logging.INFO)
 
     actx = actx_factory()
-
-    # prevent cache 'splosion
-    from sympy.core.cache import clear_cache
-    clear_cache()
 
     from pytools.convergence import EOCRecorder
     logger.info("\n%s", str(case))

--- a/test/test_stokes.py
+++ b/test/test_stokes.py
@@ -40,6 +40,9 @@ import extra_int_eq_data as eid
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])

--- a/test/test_symbolic.py
+++ b/test/test_symbolic.py
@@ -40,6 +40,9 @@ from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])

--- a/test/test_target_specific_qbx.py
+++ b/test/test_target_specific_qbx.py
@@ -35,6 +35,9 @@ from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -33,6 +33,9 @@ from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 import logging
 logger = logging.getLogger(__name__)
 
+from pytential.utils import (  # noqa: F401
+        pytest_teardown_function as teardown_function)
+
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])


### PR DESCRIPTION
This contains my collection of attempts at mitigating #59. I don't know that there's anything really decisive in here, but there is a collection of things that each make a small amount of difference. So :shrug:... that's all the time I think I can afford to devote to this. Maybe it'll help some.

There are various related PRs across the stack, including:

- https://github.com/inducer/pyopencl/pull/694
- https://github.com/inducer/pytools/pull/182
- https://github.com/inducer/loopy/pull/797
- https://github.com/inducer/loopy/pull/798
- https://github.com/inducer/pytato/pull/450
- https://github.com/inducer/arraycontext/pull/241