### PR TITLE
Type `SKELETONIZE_TEST_CASES`

### DIFF
--- a/test/test_linalg_skeletonization.py
+++ b/test/test_linalg_skeletonization.py
@@ -22,6 +22,7 @@ THE SOFTWARE.
 
 from dataclasses import replace
 from functools import partial
+from typing import Sequence, Union
 import pytest
 
 import numpy as np
@@ -47,7 +48,7 @@ pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])
 
-SKELETONIZE_TEST_CASES = [
+SKELETONIZE_TEST_CASES: Sequence[Union[extra.CurveTestCase, extra.TorusTestCase]] = [
         extra.CurveTestCase(
             name="ellipse",
             op_type="scalar",


### PR DESCRIPTION
Addresses recent CI failures:
```
test/test_linalg_skeletonization.py:96: error: Unexpected keyword argument "knl_class_or_helmholtz_k" for "replace" of "MatrixTestCaseMixin"  [call-arg]
test/test_linalg_skeletonization.py:97: error: Unexpected keyword argument "knl_class_or_helmholtz_k" for "replace" of "MatrixTestCaseMixin"  [call-arg]
test/test_linalg_skeletonization.py:99: error: Unexpected keyword argument "knl_class_or_helmholtz_k" for "replace" of "MatrixTestCaseMixin"  [call-arg]
test/test_linalg_skeletonization.py:100: error: Unexpected keyword argument "knl_class_or_helmholtz_k" for "replace" of "MatrixTestCaseMixin"  [call-arg]
test/test_linalg_skeletonization.py:384: error: Unexpected keyword argument "resolutions" for "replace" of "MatrixTestCaseMixin"  [call-arg]
test/test_linalg_skeletonization.py:385: error: Unexpected keyword argument "resolutions" for "replace" of "MatrixTestCaseMixin"  [call-arg]
test/test_linalg_skeletonization.py:386: error: Unexpected keyword argument "resolutions" for "replace" of "MatrixTestCaseMixin"  [call-arg]
```

https://github.com/inducer/pytential/actions/runs/5845078335/job/15848814014

cc @alexfikl 