### PR TITLE
pylint: ignore matplotlib

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         -   uses: actions/checkout@v3
         -   name: "Main Script"
             run: |
-                echo "- matplotlib" >> .test-conda-env-py3.yml
+                export EXTRA_INSTALL="pyvisfile matplotlib"
 
                 curl -L -O https://tiker.net/ci-support-v0
                 . ci-support-v0


### PR DESCRIPTION
This removes matplotlib from the CI and ignores it in `pylint`, so hopefully it won't take an eternity to run now :heart: It could be even faster with the `mamba` changes on the CI!

Fixes #215 