### PR TITLE
tests: disable high memory test case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,8 +85,9 @@ jobs:
         -   uses: actions/checkout@v3
         -   name: "Main Script"
             run: |
+                export PYTEST_PARALLEL_FLAGS='-n 2'
                 export SUMPY_FORCE_SYMBOLIC_BACKEND=sympy
-                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-m 'not slowtest'"}
+                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-m 'not slowtest and not memory'"}
 
                 curl -L -O https://tiker.net/ci-support-v0
                 . ci-support-v0
@@ -104,10 +105,11 @@ jobs:
                 echo "- compilers" >> .test-conda-env.yml
                 echo "- llvm-openmp" >> .test-conda-env.yml
 
+                export PYTEST_PARALLEL_FLAGS='-n 2'
                 export LC_ALL=en_US.UTF-8
                 export LANG=en_US.UTF-8
                 export CONDA_ENVIRONMENT=.test-conda-env.yml
-                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-m 'not slowtest'"}
+                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-m 'not slowtest and not memory'"}
 
                 curl -L -O https://tiker.net/ci-support-v0
                 . ci-support-v0
@@ -121,8 +123,9 @@ jobs:
         -   uses: actions/checkout@v3
         -   name: "Main Script"
             run: |
+                export PYTEST_PARALLEL_FLAGS='-n 2'
                 export SUMPY_FORCE_SYMBOLIC_BACKEND=symengine
-                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-m 'not slowtest'"}
+                export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-m 'not slowtest and not memory'"}
 
                 curl -L -O https://tiker.net/ci-support-v0
                 . ci-support-v0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
         -   uses: actions/checkout@v3
         -   name: "Main Script"
             run: |
+                export SUMPY_FFT_BACKEND=loopy
                 export PYTEST_PARALLEL_FLAGS='-n 2'
                 export SUMPY_FORCE_SYMBOLIC_BACKEND=sympy
                 export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-m 'not slowtest and not memory'"}
@@ -105,6 +106,7 @@ jobs:
                 echo "- compilers" >> .test-conda-env.yml
                 echo "- llvm-openmp" >> .test-conda-env.yml
 
+                export SUMPY_FFT_BACKEND=loopy
                 export PYTEST_PARALLEL_FLAGS='-n 2'
                 export LC_ALL=en_US.UTF-8
                 export LANG=en_US.UTF-8
@@ -123,6 +125,7 @@ jobs:
         -   uses: actions/checkout@v3
         -   name: "Main Script"
             run: |
+                export SUMPY_FFT_BACKEND=loopy
                 export PYTEST_PARALLEL_FLAGS='-n 2'
                 export SUMPY_FORCE_SYMBOLIC_BACKEND=symengine
                 export PYTEST_ADDOPTS=${PYTEST_ADDOPTS:-"-m 'not slowtest and not memory'"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 numpy != 1.22.0
 
 git+https://github.com/inducer/pytools.git#egg=pytools
-git+https://github.com/inducer/pymbolic.git#egg=pymbolic
+git+https://github.com/inducer/pymbolic.git@attrs#egg=pymbolic
 sympy
 git+https://github.com/inducer/modepy.git#egg=modepy
 git+https://github.com/inducer/pyopencl.git#egg=pyopencl

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ multiline-quotes = """
 [tool:pytest]
 markers=
     slowtest: mark a test as slow
+    memory: mark test as using too much memory
 
 [mypy]
 python_version = 3.8

--- a/test/test_layer_pot.py
+++ b/test/test_layer_pot.py
@@ -436,7 +436,11 @@ def test_unregularized_off_surface_fmm_vs_direct(actx_factory):
 
 # {{{ test 3D jump relations
 
-@pytest.mark.parametrize("relation", ["sp", "nxcurls", "div_s"])
+@pytest.mark.parametrize("relation", [
+    pytest.param("sp", marks=pytest.mark.memory),
+    "nxcurls",
+    "div_s",
+    ])
 def test_3d_jump_relations(actx_factory, relation, visualize=False):
     pytest.importorskip("pyfmmlib")
     actx = actx_factory()

--- a/test/test_layer_pot_eigenvalues.py
+++ b/test/test_layer_pot_eigenvalues.py
@@ -51,10 +51,10 @@ pytest_generate_tests = pytest_generate_tests_for_array_contexts([
         [
             (1, 5, 3, False),
             (1, 6, 3, False),
-            (2, 5, 3, False),
+            pytest.param((2, 5, 3, False), marks=pytest.mark.memory),
             (1, 5, 4, False),
             (1, 7, 5, False),
-            (2, 7, 5, False),
+            pytest.param((2, 7, 5, False), marks=pytest.mark.memory),
 
             (2, 7, 5, True),
             ])

--- a/test/test_layer_pot_identity.py
+++ b/test/test_layer_pot_identity.py
@@ -199,22 +199,16 @@ class DynamicTestCase:
 
 # {{{ integral identity tester
 
-
-@pytest.mark.slowtest
-@pytest.mark.parametrize("case", [
-        DynamicTestCase(SphereTestCase(), GreenExpr(), 0),
-])
-def test_identity_convergence_slow(actx_factory, case):
-    test_identity_convergence(actx_factory, case)
-
-
 @pytest.mark.parametrize("case", [
         # 2d
         DynamicTestCase(ied.StarfishTestCase(), GreenExpr(), 0),
         DynamicTestCase(ied.StarfishTestCase(), GreenExpr(), 1.2),
-        DynamicTestCase(ied.StarfishTestCase(), GradGreenExpr(), 0),
-        DynamicTestCase(ied.StarfishTestCase(), GradGreenExpr(), 1.2),
-        DynamicTestCase(ied.StarfishTestCase(), ZeroCalderonExpr(), 0),
+        pytest.param(DynamicTestCase(ied.StarfishTestCase(), GradGreenExpr(), 0),
+                     marks=pytest.mark.memory),
+        pytest.param(DynamicTestCase(ied.StarfishTestCase(), GradGreenExpr(), 1.2),
+                     marks=pytest.mark.memory),
+        pytest.param(DynamicTestCase(ied.StarfishTestCase(), ZeroCalderonExpr(), 0),
+                     marks=pytest.mark.memory),
         # test target derivatives with direct evaluation
         DynamicTestCase(
             ied.StarfishTestCase(), ZeroCalderonExpr(), 0, fmm_order=False),
@@ -223,6 +217,8 @@ def test_identity_convergence_slow(actx_factory, case):
         DynamicTestCase(
             ied.StarfishTestCase(), GreenExpr(), 1.2, fmm_backend="fmmlib"),
         # 3d
+        pytest.param(DynamicTestCase(SphereTestCase(), GreenExpr(), 0),
+                     marks=pytest.mark.slowtest),
         DynamicTestCase(SphereTestCase(), GreenExpr(), 0, fmm_backend="fmmlib"),
         DynamicTestCase(SphereTestCase(), GreenExpr(), 1.2, fmm_backend="fmmlib"),
         DynamicTestCase(QuadSphereTestCase(), GreenExpr(), 0, fmm_backend="fmmlib"),

--- a/test/test_scalar_int_eq.py
+++ b/test/test_scalar_int_eq.py
@@ -20,7 +20,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
+from typing import List, Union
+
 import pytest
+import _pytest
 
 import numpy as np
 import numpy.linalg as la
@@ -445,7 +448,7 @@ def run_int_eq_test(actx,
 
 # {{{ test frontend
 
-cases = [
+cases: List[Union[inteq.EllipseTestCase, _pytest.mark.ParameterSet]] = [
         inteq.EllipseTestCase(
             knl_class_or_helmholtz_k=helmholtz_k,
             bc_type=bc_type,
@@ -457,13 +460,19 @@ cases = [
 
 
 cases += [
-        inteq.EllipseTestCase(
-            knl_class_or_helmholtz_k=BiharmonicKernel,
-            bc_type="clamped_plate", side=-1, fmm_backend=None),
-        inteq.EllipseTestCase(
-            knl_class_or_helmholtz_k=BiharmonicKernel,
-            bc_type="clamped_plate", side=-1, fmm_backend="sumpy", fmm_order=15,
-            gmres_tol=1e-9),
+        # FIXME: this crashes the Github CI with the pymbolic dataclass port in
+        #   https://github.com/inducer/pymbolic/pull/125
+        pytest.param(
+            inteq.EllipseTestCase(
+                knl_class_or_helmholtz_k=BiharmonicKernel,
+                bc_type="clamped_plate", side=-1, fmm_backend=None),
+            marks=pytest.mark.memory),
+        pytest.param(
+            inteq.EllipseTestCase(
+                knl_class_or_helmholtz_k=BiharmonicKernel,
+                bc_type="clamped_plate", side=-1, fmm_backend="sumpy", fmm_order=15,
+                gmres_tol=1e-9),
+            marks=pytest.mark.memory),
         inteq.EllipseTestCase(
             knl_class_or_helmholtz_k=BiharmonicKernel,
             bc_type="clamped_plate", side=-1, fmm_backend="sumpy", fmm_order=15,


### PR DESCRIPTION
This is running with the `pymbolic@attrs` branch to see if there's any test case we can disable to get that running on the Github CI (seems to have memory issues). Ran
```
mprof run python -m pytest -v -s -m 'not slowtest' --memray --most-allocations=25 test
```
on `koelsch` to see which cases use the most memory. There's a bunch of tests at around 2GB a piece, so going through them to see if it works :(

TODO:
- [ ] Revert the pymbolic branch change in `requirements.txt`.