### PR TITLE
ci: bump action versions

### DIFF
--- a/.github/workflows/autopush.yml
+++ b/.github/workflows/autopush.yml
@@ -9,7 +9,7 @@ jobs:
         name: Automatic push to gitlab.tiker.net
         runs-on: ubuntu-latest
         steps:
-        -   uses: actions/checkout@v3
+        -   uses: actions/checkout@v4
         -   run: |
                 mkdir ~/.ssh && echo -e "Host gitlab.tiker.net\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
                 eval $(ssh-agent) && echo "$GITLAB_AUTOPUSH_KEY" | ssh-add -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,9 @@ jobs:
         name: Flake8
         runs-on: ubuntu-latest
         steps:
-        -   uses: actions/checkout@v3
+        -   uses: actions/checkout@v4
         -
-            uses: actions/setup-python@v4
+            uses: actions/setup-python@v5
             with:
                 # matches compat target in setup.py
                 python-version: '3.8'
@@ -29,7 +29,7 @@ jobs:
         name: Pylint
         runs-on: ubuntu-latest
         steps:
-        -   uses: actions/checkout@v3
+        -   uses: actions/checkout@v4
         -   name: "Main Script"
             run: |
                 export EXTRA_INSTALL="pyvisfile matplotlib"
@@ -48,9 +48,9 @@ jobs:
         name: Mypy
         runs-on: ubuntu-latest
         steps:
-        -   uses: actions/checkout@v3
+        -   uses: actions/checkout@v4
         -
-            uses: actions/setup-python@v4
+            uses: actions/setup-python@v5
             with:
                 python-version: '3.x'
         -   name: "Main Script"
@@ -66,9 +66,9 @@ jobs:
         name: Documentation
         runs-on: ubuntu-latest
         steps:
-        -   uses: actions/checkout@v3
+        -   uses: actions/checkout@v4
         -
-            uses: actions/setup-python@v4
+            uses: actions/setup-python@v5
             with:
                 python-version: '3.x'
         -   name: "Main Script"
@@ -82,7 +82,7 @@ jobs:
         name: Pytest Linux
         runs-on: ubuntu-latest
         steps:
-        -   uses: actions/checkout@v3
+        -   uses: actions/checkout@v4
         -   name: "Main Script"
             run: |
                 export SUMPY_FORCE_SYMBOLIC_BACKEND=sympy
@@ -97,7 +97,7 @@ jobs:
         name: Pytest Mac
         runs-on: macos-latest
         steps:
-        -   uses: actions/checkout@v3
+        -   uses: actions/checkout@v4
         -   name: "Main Script"
             run: |
                 grep -v symengine .test-conda-env-py3.yml > .test-conda-env.yml
@@ -118,7 +118,7 @@ jobs:
         name: Pytest with SymEngine
         runs-on: ubuntu-latest
         steps:
-        -   uses: actions/checkout@v3
+        -   uses: actions/checkout@v4
         -   name: "Main Script"
             run: |
                 export SUMPY_FORCE_SYMBOLIC_BACKEND=symengine
@@ -133,7 +133,7 @@ jobs:
         name: Examples
         runs-on: ubuntu-latest
         steps:
-        -   uses: actions/checkout@v3
+        -   uses: actions/checkout@v4
         -   name: "Main Script"
             run: |
                 export EXTRA_INSTALL="pyvisfile matplotlib"


### PR DESCRIPTION
Noticed `meshmode` bumped them the other day, so went ahead and bumped them here too.

Is it worth adding a `dependabot` or something to bump these automatically?