### PR TITLE
Fix new C409 errors

### DIFF
--- a/examples/fmm-error.py
+++ b/examples/fmm-error.py
@@ -29,7 +29,7 @@ def main():
         kernel = LaplaceKernel(2)
 
     mesh = make_curve_mesh(
-            #lambda t: ellipse(1, t),
+            # lambda t: ellipse(1, t),
             starfish,
             np.linspace(0, 1, nelements+1),
             target_order)

--- a/examples/helmholtz-dirichlet.py
+++ b/examples/helmholtz-dirichlet.py
@@ -72,7 +72,7 @@ def main(mesh_name="ellipse", visualize=False):
             InterpolatoryQuadratureSimplexGroupFactory(bdry_quad_order))
 
     from pytential.qbx import (
-            QBXLayerPotentialSource, QBXTargetAssociationFailedException)
+            QBXLayerPotentialSource, QBXTargetAssociationFailedError)
     qbx = QBXLayerPotentialSource(
             pre_density_discr, fine_order=bdry_ovsmp_quad_order, qbx_order=qbx_order,
             fmm_order=fmm_order
@@ -165,13 +165,13 @@ def main(mesh_name="ellipse", visualize=False):
         fld_in_vol = actx.to_numpy(
                 bind(places, representation_sym)(
                     actx, sigma=gmres_result.solution, k=k))
-    except QBXTargetAssociationFailedException as e:
+    except QBXTargetAssociationFailedError as e:
         fplot.write_vtk_file("helmholtz-dirichlet-failed-targets.vts", [
             ("failed", actx.to_numpy(e.failed_target_flags))
             ])
         raise
 
-    #fplot.show_scalar_in_mayavi(fld_in_vol.real, max_val=5)
+    # fplot.show_scalar_in_mayavi(fld_in_vol.real, max_val=5)
     fplot.write_vtk_file("helmholtz-dirichlet-potential.vts", [
         ("potential", fld_in_vol),
         ("indicator", indicator),

--- a/examples/laplace-dirichlet-3d.py
+++ b/examples/laplace-dirichlet-3d.py
@@ -65,7 +65,7 @@ def main(mesh_name="torus", visualize=False):
             InterpolatoryQuadratureSimplexGroupFactory(bdry_quad_order))
 
     from pytential.qbx import (
-            QBXLayerPotentialSource, QBXTargetAssociationFailedException)
+            QBXLayerPotentialSource, QBXTargetAssociationFailedError)
     qbx = QBXLayerPotentialSource(
             pre_density_discr, fine_order=bdry_ovsmp_quad_order, qbx_order=qbx_order,
             fmm_order=fmm_order,
@@ -89,7 +89,7 @@ def main(mesh_name="torus", visualize=False):
     kernel = LaplaceKernel(3)
 
     sigma_sym = sym.var("sigma")
-    #sqrt_w = sym.sqrt_jac_q_weight(3)
+    # sqrt_w = sym.sqrt_jac_q_weight(3)
     sqrt_w = 1
     inv_sqrt_w_sigma = sym.cse(sigma_sym/sqrt_w)
 
@@ -150,13 +150,13 @@ def main(mesh_name="torus", visualize=False):
     try:
         fld_in_vol = actx.to_numpy(
                 bind(places, representation_sym)(actx, sigma=sigma))
-    except QBXTargetAssociationFailedException as e:
+    except QBXTargetAssociationFailedError as e:
         fplot.write_vtk_file("laplace-dirichlet-3d-failed-targets.vts", [
             ("failed", actx.to_numpy(e.failed_target_flags)),
             ])
         raise
 
-    #fplot.show_scalar_in_mayavi(fld_in_vol.real, max_val=5)
+    # fplot.show_scalar_in_mayavi(fld_in_vol.real, max_val=5)
     fplot.write_vtk_file("laplace-dirichlet-3d-potential.vts", [
         ("potential", fld_in_vol),
         ])

--- a/examples/layerpot-3d.py
+++ b/examples/layerpot-3d.py
@@ -79,9 +79,9 @@ def main(mesh_name="ellipsoid"):
     else:
         kernel = LaplaceKernel(3)
 
-    #op = sym.d_dx(sym.S(kernel, sym.var("sigma"), qbx_forced_limit=None))
+    # op = sym.d_dx(sym.S(kernel, sym.var("sigma"), qbx_forced_limit=None))
     op = sym.D(kernel, sym.var("sigma"), qbx_forced_limit=None)
-    #op = sym.S(kernel, sym.var("sigma"), qbx_forced_limit=None)
+    # op = sym.S(kernel, sym.var("sigma"), qbx_forced_limit=None)
 
     if 0:
         from random import randrange
@@ -98,7 +98,7 @@ def main(mesh_name="ellipsoid"):
             bind(places, op, auto_where=("qbx", "targets"))(
                 actx, sigma=sigma, k=k))
 
-    #fplot.show_scalar_in_mayavi(fld_in_vol.real, max_val=5)
+    # fplot.show_scalar_in_mayavi(fld_in_vol.real, max_val=5)
     fplot.write_vtk_file("layerpot-3d-potential.vts", [
         ("potential", fld_in_vol)
         ])

--- a/examples/layerpot.py
+++ b/examples/layerpot.py
@@ -43,7 +43,7 @@ def main(curve_fn=starfish, visualize=True):
             pre_density_discr, 4*target_order, qbx_order,
             fmm_order=False,
             target_association_tolerance=0.005,
-            #fmm_backend="fmmlib",
+            # fmm_backend="fmmlib",
             )
 
     from pytential.target import PointsTarget
@@ -71,7 +71,7 @@ def main(curve_fn=starfish, visualize=True):
     def op(**kwargs):
         kwargs.update(kernel_kwargs)
 
-        #return sym.d_dx(2, sym.S(kernel, sym.var("sigma"), **kwargs))
+        # return sym.d_dx(2, sym.S(kernel, sym.var("sigma"), **kwargs))
         # return sym.D(kernel, sym.var("sigma"), **kwargs)
         return sym.S(kernel, sym.var("sigma"), **kwargs)
 

--- a/examples/scaling-study.py
+++ b/examples/scaling-study.py
@@ -67,7 +67,7 @@ def timing_run(nx, ny, visualize=False):
             InterpolatoryQuadratureSimplexGroupFactory(bdry_quad_order))
 
     from pytential.qbx import (
-            QBXLayerPotentialSource, QBXTargetAssociationFailedException)
+            QBXLayerPotentialSource, QBXTargetAssociationFailedError)
     qbx = QBXLayerPotentialSource(
             density_discr, fine_order=bdry_ovsmp_quad_order, qbx_order=qbx_order,
             fmm_order=fmm_order
@@ -169,7 +169,7 @@ def timing_run(nx, ny, visualize=False):
                         auto_where=("qbx_target_assoc", "plot_targets")
                         )(actx, sigma=sigma, k=k)
                     )
-        except QBXTargetAssociationFailedException as e:
+        except QBXTargetAssociationFailedError as e:
             fplot.write_vtk_file("scaling-study-failed-targets.vts", [
                 ("failed", actx.to_numpy(e.failed_target_flags)),
                 ])

--- a/experiments/cahn-hilliard.py
+++ b/experiments/cahn-hilliard.py
@@ -41,7 +41,7 @@ def main():
             InterpolatoryQuadratureSimplexGroupFactory(bdry_quad_order))
 
     from pytential.qbx import (
-            QBXLayerPotentialSource, QBXTargetAssociationFailedException)
+            QBXLayerPotentialSource, QBXTargetAssociationFailedError)
     qbx, _ = QBXLayerPotentialSource(
             pre_density_discr, fine_order=bdry_ovsmp_quad_order, qbx_order=qbx_order,
             fmm_order=fmm_order,
@@ -107,7 +107,7 @@ def main():
         fld_in_vol = bind(
                 (qbx_stick_out, PointsTarget(targets)),
                 chop.representation(unk))(queue, sigma=sigma).get()
-    except QBXTargetAssociationFailedException as e:
+    except QBXTargetAssociationFailedError as e:
         fplot.write_vtk_file(
                 "failed-targets.vts",
                 [

--- a/experiments/maxwell.py
+++ b/experiments/maxwell.py
@@ -247,7 +247,7 @@ def main():
 
         qbx_tgt_tol = qbx.copy(target_association_tolerance=0.1)
         from pytential.target import PointsTarget
-        from pytential.qbx import QBXTargetAssociationFailedException
+        from pytential.qbx import QBXTargetAssociationFailedError
 
         rho_sym = sym.var("rho")
 
@@ -265,7 +265,7 @@ def main():
                             qbx_forced_limit=None)),
                         ])
                     )(queue, jt=jt, rho=rho, k=k)
-        except QBXTargetAssociationFailedException as e:
+        except QBXTargetAssociationFailedError as e:
             fplot.write_vtk_file(
                     "failed-targets.vts",
                     [

--- a/experiments/maxwell_sphere.py
+++ b/experiments/maxwell_sphere.py
@@ -248,7 +248,7 @@ def main():
 
         qbx_stick_out = qbx.copy(target_stick_out_factor=0.1)
         from pytential.target import PointsTarget
-        from pytential.qbx import QBXTargetAssociationFailedException
+        from pytential.qbx import QBXTargetAssociationFailedError
 
         rho_sym = sym.var("rho")
 
@@ -266,7 +266,7 @@ def main():
                             qbx_forced_limit=None)),
                         ])
                     )(queue, jt=jt, rho=rho, k=k)
-        except QBXTargetAssociationFailedException as e:
+        except QBXTargetAssociationFailedError as e:
             fplot.write_vtk_file(
                     "failed-targets.vts",
                     [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,14 +92,10 @@ extend-select = [
 extend-ignore = [
     "C90",  # McCabe complexity
     "E226", # missing whitespace around arithmetic operator
-    "E241", # multiple spaces after comma
-    "E242", # tab after comma
-    "E265", # comment should have a space
     "E402", # module level import not at the top of file
     "N802", # function name should be lowercase
     "N803", # argument name should be lowercase
     "N806", # variable name should be lowercase
-    "N818", # error suffix in exception names
     "RUF012", # ClassVar for mutable class attributes
     "RUF022", # __all__ is not sorted
     "UP031", # use f-strings instead of %

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,6 @@ extend-select = [
 ]
 extend-ignore = [
     "C90",  # McCabe complexity
-    "B028", # no explicit stacklevel in warnings
     "E226", # missing whitespace around arithmetic operator
     "E241", # multiple spaces after comma
     "E242", # tab after comma

--- a/pytential/collection.py
+++ b/pytential/collection.py
@@ -419,7 +419,8 @@ def add_geometry_to_collection(
         if key not in known_cache_keys:
             from warnings import warn
             warn(f"GeometryCollection cache key '{key}' is not known and will "
-                 "be dropped in the new collection.")
+                 "be dropped in the new collection.",
+                 stacklevel=2)
             continue
 
         new_cache = new_places._get_cache(key)

--- a/pytential/linalg/direct_solver_symbolic.py
+++ b/pytential/linalg/direct_solver_symbolic.py
@@ -88,7 +88,7 @@ class KernelTransformationRemover(IdentityMapper):
 
     def map_int_g(self, expr):
         target_kernel = self.txr(expr.target_kernel)
-        source_kernels = tuple([self.sxr(kernel) for kernel in expr.source_kernels])
+        source_kernels = tuple(self.sxr(kernel) for kernel in expr.source_kernels)
         if (target_kernel == expr.target_kernel
                 and source_kernels == expr.source_kernels):
             return expr

--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -834,13 +834,13 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
                 assert o.qbx_forced_limit is not None
                 assert abs(o.qbx_forced_limit) > 0
 
-                self_outputs[(o.target_name, o.qbx_forced_limit)].append((i, o))
+                self_outputs[o.target_name, o.qbx_forced_limit].append((i, o))
             else:
                 qbx_forced_limit = o.qbx_forced_limit
                 if qbx_forced_limit is None:
                     qbx_forced_limit = 0
 
-                other_outputs[(o.target_name, qbx_forced_limit)].append((i, o))
+                other_outputs[o.target_name, qbx_forced_limit].append((i, o))
 
         queue = actx.queue
         results = [None] * len(insn.outputs)

--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -32,7 +32,7 @@ from pytools import memoize_method, memoize_in, single_valued
 from sumpy.expansion import DefaultExpansionFactory as DefaultExpansionFactoryBase
 
 from pytential.qbx.cost import AbstractQBXCostModel
-from pytential.qbx.target_assoc import QBXTargetAssociationFailedException
+from pytential.qbx.target_assoc import QBXTargetAssociationFailedError
 from pytential.source import LayerPotentialSourceBase
 
 import logging
@@ -42,7 +42,7 @@ logger = logging.getLogger(__name__)
 __doc__ = """
 .. autoclass:: QBXLayerPotentialSource
 
-.. autoclass:: QBXTargetAssociationFailedException
+.. autoclass:: QBXTargetAssociationFailedError
 
 .. autoclass:: DefaultExpansionFactory
 
@@ -986,7 +986,7 @@ def get_flat_strengths_from_densities(
 
 __all__ = (
         "QBXLayerPotentialSource",
-        "QBXTargetAssociationFailedException",
+        "QBXTargetAssociationFailedError",
         )
 
 # vim: fdm=marker

--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -507,7 +507,8 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
             from warnings import warn
             warn(
                     "Executing global QBX without refinement. "
-                    "This is unlikely to work.")
+                    "This is unlikely to work.",
+                    stacklevel=3)
 
         if extra_args is None:
             extra_args = {}
@@ -771,7 +772,8 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
             from warnings import warn
             warn(
                     "Timing data collection not supported.",
-                    category=UnableToCollectTimingData)
+                    category=UnableToCollectTimingData,
+                    stacklevel=2)
 
         # {{{ evaluate and flatten inputs
 

--- a/pytential/qbx/geometry.py
+++ b/pytential/qbx/geometry.py
@@ -992,7 +992,7 @@ class QBXFMMGeometryData(FMMLibRotationDataInterface):
         # }}}
 
         pt.gca().set_aspect("equal")
-        #pt.legend()
+        # pt.legend()
         pt.savefig(
                 "geodata-stage2-nelem%d.pdf"
                 % stage2_density_discr.mesh.nelements)

--- a/pytential/qbx/refinement.py
+++ b/pytential/qbx/refinement.py
@@ -507,9 +507,10 @@ def _warn_max_iterations(violated_criteria, expansion_disturbance_tolerance):
                 len(violated_criteria),
                 expansion_disturbance_tolerance,
                 ", ".join(
-                    "%d: %s" % (i+1, vc_text)
+                    f"{i + 1}: {vc_text}"
                     for i, vc_text in enumerate(violated_criteria))),
-            RefinerNotConvergedWarning)
+            RefinerNotConvergedWarning,
+            stacklevel=5)
 
 
 def _visualize_refinement(actx: PyOpenCLArrayContext, discr,

--- a/pytential/qbx/target_assoc.py
+++ b/pytential/qbx/target_assoc.py
@@ -410,11 +410,12 @@ QBX_FAILED_TARGET_ASSOCIATION_REFINER = AreaQueryElementwiseTemplate(
 
 # {{{ target associator
 
-class QBXTargetAssociationFailedException(Exception):
+class QBXTargetAssociationFailedError(Exception):
     """
     .. attribute:: refine_flags
     .. attribute:: failed_target_flags
     """
+
     def __init__(self, refine_flags, failed_target_flags, message):
         self.refine_flags = refine_flags
         self.failed_target_flags = failed_target_flags
@@ -429,6 +430,10 @@ class QBXTargetAssociationFailedException(Exception):
 
     def __repr__(self):
         return "<%s>" % type(self).__name__
+
+
+# NOTE: this is deprecated
+QBXTargetAssociationFailedException = QBXTargetAssociationFailedError
 
 
 class QBXTargetAssociation(DeviceDataRecord):
@@ -832,7 +837,7 @@ def associate_targets_to_qbx_centers(places, geometry, wrangler,
 
         The side request can take on the values in :ref:`qbx-side-request-table`.
 
-    :raises pytential.qbx.QBXTargetAssociationFailedException:
+    :raises pytential.qbx.QBXTargetAssociationFailedError:
         when target association failed to find a center for a target.
         The returned exception object contains suggested refine flags.
 
@@ -899,7 +904,7 @@ def associate_targets_to_qbx_centers(places, geometry, wrangler,
                 debug)
 
         assert have_element_to_refine
-        raise QBXTargetAssociationFailedException(
+        raise QBXTargetAssociationFailedError(
                 refine_flags=actx.freeze(refine_flags),
                 failed_target_flags=actx.freeze(center_not_found),
                 message=fail_msg)

--- a/pytential/solve.py
+++ b/pytential/solve.py
@@ -3,4 +3,5 @@ from pytential.linalg.gmres import *        # noqa: F403
 from warnings import warn
 warn(
     "pytential.solve is deprecated and will be removed in 2023. Use "
-    "pytential.linalg.gmres instead.", DeprecationWarning)
+    "pytential.linalg.gmres instead.", DeprecationWarning,
+    stacklevel=1)

--- a/pytential/source.py
+++ b/pytential/source.py
@@ -213,7 +213,8 @@ class PointPotentialSource(_SumpyP2PMixin, PotentialSource):
             from warnings import warn
             warn(
                    "Timing data collection not supported.",
-                   category=UnableToCollectTimingData)
+                   category=UnableToCollectTimingData,
+                   stacklevel=2)
 
         p2p = None
 

--- a/pytential/symbolic/compiler.py
+++ b/pytential/symbolic/compiler.py
@@ -351,7 +351,7 @@ class Code:
 
 # {{{ scheduler
 
-class _NoStatementAvailable(Exception):
+class _NoStatementAvailableError(Exception):
     pass
 
 
@@ -372,7 +372,7 @@ def _get_next_step(
                 <= available_names)]
 
     if not available_stmts:
-        raise _NoStatementAvailable
+        raise _NoStatementAvailableError
 
     needed_vars = {
         dep.name
@@ -434,7 +434,7 @@ def _compute_schedule(
                     result,
                     available_vars,
                     frozenset(done_stmts))
-        except _NoStatementAvailable:
+        except _NoStatementAvailableError:
             # no available statements: we're done
             break
 

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -172,15 +172,15 @@ class EvaluationMapperBase(PymbolicEvaluationMapper):
         operand = self.rec(expr.operand)
 
         if dofdesc.granularity is sym.GRANULARITY_NODE:
-            return type(operand)(actx, tuple([
+            return type(operand)(actx, tuple(
                 actx.call_loopy(node_knl(), operand=operand_i)["result"]
                 for operand_i in operand
-                ]))
+                ))
         elif dofdesc.granularity is sym.GRANULARITY_ELEMENT:
-            return type(operand)(actx, tuple([
+            return type(operand)(actx, tuple(
                 actx.call_loopy(element_knl(), operand=operand_i)["result"]
                 for operand_i in operand
-                ]))
+                ))
         else:
             raise ValueError(f"unsupported granularity: {dofdesc.granularity}")
 

--- a/pytential/symbolic/pde/maxwell/waveguide.py
+++ b/pytential/symbolic/pde/maxwell/waveguide.py
@@ -99,7 +99,7 @@ class SecondKindInfZMuellerOperator(L2WeightedPDEOperator):
         for i in range(len(self.interfaces)):
             for current in ["j", "m"]:
                 for cur_dir in ["z", "t"]:
-                    result[(current + cur_dir, i)] = len(result)
+                    result[current + cur_dir, i] = len(result)
 
         return result
 

--- a/pytential/unregularized.py
+++ b/pytential/unregularized.py
@@ -105,7 +105,8 @@ class UnregularizedLayerPotentialSource(LayerPotentialSourceBase):
             from pytential.source import UnableToCollectTimingData
             warn(
                    "Timing data collection not supported.",
-                   category=UnableToCollectTimingData)
+                   category=UnableToCollectTimingData,
+                   stacklevel=2)
 
         from pytools.obj_array import obj_array_vectorize
 

--- a/pytential/version.py
+++ b/pytential/version.py
@@ -25,7 +25,7 @@ from importlib import metadata
 from pytools import find_module_git_revision
 
 VERSION_TEXT = metadata.version("pytential")
-VERSION = tuple([int(i) for i in VERSION_TEXT.split(".")])
+VERSION = tuple(int(i) for i in VERSION_TEXT.split("."))
 
 _GIT_REVISION = find_module_git_revision(__file__, n_levels_up=1)
 PYTENTIAL_KERNEL_VERSION = (*VERSION, _GIT_REVISION, 0)

--- a/test/test_global_qbx.py
+++ b/test/test_global_qbx.py
@@ -542,10 +542,10 @@ def test_target_association_failure(actx_factory):
 
     from pytential.qbx.target_assoc import (
             target_association_code_container, associate_targets_to_qbx_centers,
-            QBXTargetAssociationFailedException)
+            QBXTargetAssociationFailedError)
     code_container = target_association_code_container(actx)
 
-    with pytest.raises(QBXTargetAssociationFailedException):
+    with pytest.raises(QBXTargetAssociationFailedError):
         associate_targets_to_qbx_centers(
             places,
             places.auto_source,

--- a/test/test_layer_pot.py
+++ b/test/test_layer_pot.py
@@ -145,7 +145,7 @@ def test_off_surface_eval(actx_factory, use_fmm, visualize=False):
 
 # {{{ test off-surface eval vs direct
 
-def test_off_surface_eval_vs_direct(actx_factory,  do_plot=False):
+def test_off_surface_eval_vs_direct(actx_factory, do_plot=False):
     logging.basicConfig(level=logging.INFO)
 
     actx = actx_factory()
@@ -191,14 +191,14 @@ def test_off_surface_eval_vs_direct(actx_factory,  do_plot=False):
     direct_density_discr = places.get_discretization("direct_qbx")
     fmm_density_discr = places.get_discretization("fmm_qbx")
 
-    from pytential.qbx import QBXTargetAssociationFailedException
+    from pytential.qbx import QBXTargetAssociationFailedError
     op = sym.D(LaplaceKernel(2), sym.var("sigma"), qbx_forced_limit=None)
     try:
         direct_sigma = direct_density_discr.zeros(actx) + 1
         direct_fld_in_vol = bind(places, op,
                 auto_where=("direct_qbx", "target"))(
                         actx, sigma=direct_sigma)
-    except QBXTargetAssociationFailedException as e:
+    except QBXTargetAssociationFailedError as e:
         fplot.show_scalar_in_matplotlib(
             actx.to_numpy(actx.thaw(e.failed_target_flags)))
         import matplotlib.pyplot as pt
@@ -227,7 +227,7 @@ def test_off_surface_eval_vs_direct(actx_factory,  do_plot=False):
 
 # {{{
 
-def test_single_plus_double_with_single_fmm(actx_factory,  do_plot=False):
+def test_single_plus_double_with_single_fmm(actx_factory, do_plot=False):
     logging.basicConfig(level=logging.INFO)
 
     actx = actx_factory()
@@ -274,7 +274,7 @@ def test_single_plus_double_with_single_fmm(actx_factory,  do_plot=False):
     fmm_density_discr = places.get_discretization("fmm_qbx")
 
     knl = LaplaceKernel(2)
-    from pytential.qbx import QBXTargetAssociationFailedException
+    from pytential.qbx import QBXTargetAssociationFailedError
     op_d = sym.D(knl, sym.var("sigma"), qbx_forced_limit=None)
     op_s = sym.S(knl, sym.var("sigma"), qbx_forced_limit=None)
     op = op_d + op_s * 0.5
@@ -283,7 +283,7 @@ def test_single_plus_double_with_single_fmm(actx_factory,  do_plot=False):
         direct_fld_in_vol = bind(places, op,
                 auto_where=("direct_qbx", "target"))(
                         actx, sigma=direct_sigma)
-    except QBXTargetAssociationFailedException as e:
+    except QBXTargetAssociationFailedError as e:
         fplot.show_scalar_in_matplotlib(
             actx.to_numpy(actx.thaw(e.failed_target_flags)))
         import matplotlib.pyplot as pt

--- a/test/test_layer_pot_identity.py
+++ b/test/test_layer_pot_identity.py
@@ -81,7 +81,7 @@ class GradGreenExpr:
     def get_zero_op(self, kernel, **knl_kwargs):
         d = kernel.dim
         u_sym = sym.var("u")
-        grad_u_sym = sym.make_sym_mv("grad_u",  d)
+        grad_u_sym = sym.make_sym_mv("grad_u", d)
         dn_u_sym = sym.var("dn_u")
 
         return (
@@ -227,7 +227,7 @@ def test_identity_convergence_slow(actx_factory, case):
         DynamicTestCase(SphereTestCase(), GreenExpr(), 1.2, fmm_backend="fmmlib"),
         DynamicTestCase(QuadSphereTestCase(), GreenExpr(), 0, fmm_backend="fmmlib"),
 ])
-def test_identity_convergence(actx_factory,  case, visualize=False):
+def test_identity_convergence(actx_factory, case, visualize=False):
     if case.fmm_backend == "fmmlib":
         pytest.importorskip("pyfmmlib")
     case.check()

--- a/test/test_layer_pot_identity.py
+++ b/test/test_layer_pot_identity.py
@@ -37,11 +37,11 @@ from meshmode.array_context import PytestPyOpenCLArrayContextFactory
 
 import extra_int_eq_data as ied
 import logging
-logger = logging.getLogger(__name__)
 
 from pytential.utils import (  # noqa: F401
         pytest_teardown_function as teardown_function)
 
+logger = logging.getLogger(__name__)
 pytest_generate_tests = pytest_generate_tests_for_array_contexts([
     PytestPyOpenCLArrayContextFactory,
     ])
@@ -186,15 +186,15 @@ class DynamicTestCase:
         return self.geometry.resolutions
 
     def check(self):
-        from warnings import warn
         if (self.geometry.name == "sphere"
                 and self.k != 0
                 and self.fmm_backend == "sumpy"):
-            warn("both direct eval and generating the FMM kernels are too slow")
+            logger.warning(
+                "both direct eval and generating the FMM kernels are too slow")
 
         if (self.geometry.name == "sphere"
                 and self.expr.zero_op_name == "grad_green"):
-            warn("does not achieve sufficient precision")
+            logger.warning("does not achieve sufficient precision")
 
 
 # {{{ integral identity tester
@@ -230,13 +230,8 @@ def test_identity_convergence_slow(actx_factory, case):
 def test_identity_convergence(actx_factory,  case, visualize=False):
     if case.fmm_backend == "fmmlib":
         pytest.importorskip("pyfmmlib")
-
-    logging.basicConfig(level=logging.INFO)
-
     case.check()
-
     actx = actx_factory()
-
     target_order = 8
 
     from pytools.convergence import EOCRecorder

--- a/test/test_maxwell.py
+++ b/test/test_maxwell.py
@@ -213,7 +213,7 @@ class EHField:
 
 @pytest.mark.slowtest
 @pytest.mark.parametrize("case", [
-    #tc_int,
+    # tc_int,
     tc_ext,
     ])
 def test_pec_mfie_extinction(actx_factory, case,
@@ -456,11 +456,11 @@ def test_pec_mfie_extinction(actx_factory, case,
                 ("h_bc_residual", eh_bc_values[3]),
                 ])
 
-            from pytential.qbx import QBXTargetAssociationFailedException
+            from pytential.qbx import QBXTargetAssociationFailedError
             try:
                 fplot_repr = eval_repr_at(places,
                         target="plot_targets", source="qbx_target_tol")
-            except QBXTargetAssociationFailedException as e:
+            except QBXTargetAssociationFailedError as e:
                 fplot.write_vtk_file(
                         "failed-targets.vts",
                         [

--- a/test/test_scalar_int_eq.py
+++ b/test/test_scalar_int_eq.py
@@ -240,7 +240,7 @@ def run_int_eq_test(actx,
     bound_op = bind(places, sym_op_u)
     rhs = bind(places, op.prepare_rhs(sym_bc))(actx, bc=bc)
 
-    from pytential.qbx import QBXTargetAssociationFailedException
+    from pytential.qbx import QBXTargetAssociationFailedError
     try:
         from pytential.linalg.gmres import gmres
         gmres_result = gmres(
@@ -250,7 +250,7 @@ def run_int_eq_test(actx,
                 progress=True,
                 hard_failure=True,
                 stall_iterations=50, no_progress_factor=1.05)
-    except QBXTargetAssociationFailedException as e:
+    except QBXTargetAssociationFailedError as e:
         bdry_vis = make_visualizer(actx, density_discr, case.target_order + 3)
 
         bdry_vis.write_vtk_file(f"failed-targets-solve-{resolution}.vtu", [
@@ -391,7 +391,7 @@ def run_int_eq_test(actx,
                     op.representation(sym_u),
                     auto_where=("qbx_target_tol", "plot_targets"))(
                             actx, u=weighted_u, **case.knl_concrete_kwargs)
-        except QBXTargetAssociationFailedException as e:
+        except QBXTargetAssociationFailedError as e:
             fplot.write_vtk_file(f"failed-targets-plotter-{resolution}.vts", [
                 ("failed_targets", actx.thaw(e.failed_target_flags))
                 ])

--- a/test/test_symbolic.py
+++ b/test/test_symbolic.py
@@ -320,10 +320,10 @@ def test_node_reduction(actx_factory):
 
     from meshmode.dof_array import DOFArray
     base_node_nrs = np.cumsum([0] + [grp.ndofs for grp in discr.groups])
-    ary = DOFArray(actx, tuple([
+    ary = DOFArray(actx, data=tuple(
         randrange_like(xi, offset)
         for xi, offset in zip(discr.nodes()[0], base_node_nrs)
-        ]))
+        ))
 
     n = discr.ndofs
     for func, expected in [
@@ -336,27 +336,27 @@ def test_node_reduction(actx_factory):
             )
         assert r == expected, (r, expected)
 
-    arys = tuple([rng.random(size=xi.shape) for xi in ary])
-    x = DOFArray(actx, tuple([actx.from_numpy(xi) for xi in arys]))
+    arys = tuple(rng.random(size=xi.shape) for xi in ary)
+    x = DOFArray(actx, data=tuple(actx.from_numpy(xi) for xi in arys))
 
     from meshmode.dof_array import flat_norm
     for func, np_func in [
             (sym.ElementwiseSum, np.sum),
             (sym.ElementwiseMax, np.max)
             ]:
-        expected = DOFArray(actx, tuple([
+        expected = DOFArray(actx, data=tuple(
             actx.from_numpy(np.tile(np_func(xi, axis=1, keepdims=True), xi.shape[1]))
             for xi in arys
-            ]))
+            ))
         r = bind(
             discr, func(sym.var("x"), dofdesc=sym.GRANULARITY_NODE)
             )(actx, x=x)
         assert actx.to_numpy(flat_norm(r - expected)) < 1.0e-15
 
-        expected = DOFArray(actx, tuple([
+        expected = DOFArray(actx, data=tuple(
             actx.from_numpy(np_func(xi, axis=1, keepdims=True))
             for xi in arys
-            ]))
+            ))
         r = bind(
             discr, func(sym.var("x"), dofdesc=sym.GRANULARITY_ELEMENT)
             )(actx, x=x)


### PR DESCRIPTION
This fixes the failure from ruff 0.5.7 with rule C409 and fixes two extra rules in there, since they were straightforward.