### PR TITLE
Port to new pymbolic

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -30,4 +30,5 @@ intersphinx_mapping = {
     "pytools": ("https://documen.tician.de/pytools", None),
     "scipy": ("https://docs.scipy.org/doc/scipy", None),
     "sumpy": ("https://documen.tician.de/sumpy", None),
+    "sympy": ("https://docs.sympy.org/latest/", None),
 }

--- a/pytential/linalg/direct_solver_symbolic.py
+++ b/pytential/linalg/direct_solver_symbolic.py
@@ -102,10 +102,12 @@ class KernelTransformationRemover(IdentityMapper):
             if name not in source_args
         }
 
-        return expr.copy(target_kernel=target_kernel,
-                         source_kernels=source_kernels,
-                         densities=self.rec(expr.densities),
-                         kernel_arguments=kernel_arguments)
+        from dataclasses import replace
+        return replace(expr,
+                       target_kernel=target_kernel,
+                       source_kernels=source_kernels,
+                       densities=self.rec(expr.densities),
+                       kernel_arguments=kernel_arguments)
 
 # }}}
 

--- a/pytential/linalg/skeletonization.py
+++ b/pytential/linalg/skeletonization.py
@@ -137,7 +137,7 @@ def _approximate_geometry_waa_magnitude(
             lang_version=lp.MOST_RECENT_LANGUAGE_VERSION,
             )
 
-        return knl
+        return knl.executor(actx.context)
 
     waa = bind(places, sym.weights_and_area_elements(
         places.ambient_dim, dofdesc=domain))(actx)

--- a/pytential/linalg/utils.py
+++ b/pytential/linalg/utils.py
@@ -282,7 +282,7 @@ def make_index_cluster_cartesian_product(
             lang_version=MOST_RECENT_LANGUAGE_VERSION)
 
         knl = lp.split_iname(knl, "icluster", 128, outer_tag="g.0")
-        return knl
+        return knl.executor(actx.context)
 
     @memoize_in(mindex, (make_index_cluster_cartesian_product, "index_product"))
     def _product():

--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -414,8 +414,8 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
     def op_group_features(self, expr):
         from pytential.utils import sort_arrays_together
         result = (
-                expr.source, *sort_arrays_together(expr.source_kernels,
-                expr.densities, key=str)
+                expr.source,
+                *sort_arrays_together(expr.source_kernels, expr.densities, key=str)
                 )
 
         return result

--- a/pytential/qbx/refinement.py
+++ b/pytential/qbx/refinement.py
@@ -268,7 +268,7 @@ class RefinerCodeContainer(TreeCodeContainerMixin):
             lang_version=MOST_RECENT_LANGUAGE_VERSION)
 
         knl = lp.split_iname(knl, "ielement", 128, inner_tag="l.0", outer_tag="g.0")
-        return knl
+        return knl.executor(self.array_context.context)
 
     def get_wrangler(self):
         return RefinerWrangler(self.array_context, self)
@@ -388,8 +388,8 @@ class RefinerWrangler(TreeWranglerBase):
                     sym.ElementwiseMax(
                         sym._source_danger_zone_radii(
                             stage2_density_discr.ambient_dim,
-                            dofdesc=sym.QBX_SOURCE_STAGE2),
-                        dofdesc=sym.GRANULARITY_ELEMENT)
+                            dofdesc=sym.as_dofdesc(sym.QBX_SOURCE_STAGE2)),
+                        dofdesc=sym.as_dofdesc(sym.GRANULARITY_ELEMENT))
                     )(self.array_context), self.array_context)
         unwrap_args = AreaQueryElementwiseTemplate.unwrap_args
 
@@ -633,7 +633,8 @@ def _refine_qbx_stage1(lpot_source, density_discr,
                 quad_resolution_by_element = bind(stage1_density_discr,
                         sym.ElementwiseMax(
                             sym._quad_resolution(stage1_density_discr.ambient_dim),
-                            dofdesc=sym.GRANULARITY_ELEMENT))(actx)
+                            dofdesc=sym.as_dofdesc(sym.GRANULARITY_ELEMENT)
+                            ))(actx)
 
                 violates_kernel_length_scale = \
                         wrangler.check_element_prop_threshold(
@@ -653,7 +654,8 @@ def _refine_qbx_stage1(lpot_source, density_discr,
                 scaled_max_curvature_by_element = bind(stage1_density_discr,
                     sym.ElementwiseMax(
                         sym._scaled_max_curvature(stage1_density_discr.ambient_dim),
-                        dofdesc=sym.GRANULARITY_ELEMENT))(actx)
+                        dofdesc=sym.as_dofdesc(sym.GRANULARITY_ELEMENT)
+                        ))(actx)
 
                 violates_scaled_max_curv = \
                         wrangler.check_element_prop_threshold(

--- a/pytential/qbx/target_assoc.py
+++ b/pytential/qbx/target_assoc.py
@@ -810,7 +810,7 @@ class TargetAssociationWrangler(TreeWranglerBase):
         return target_flags
 
     def make_default_target_association(self, ntargets):
-        target_to_center = self.array_context.zeros(ntargets, dtype=np.int32)
+        target_to_center = self.array_context.np.zeros(ntargets, dtype=np.int32)
         target_to_center.fill(-1)
         target_to_center.finish()
 

--- a/pytential/symbolic/dof_desc.py
+++ b/pytential/symbolic/dof_desc.py
@@ -275,6 +275,8 @@ def as_dofdesc(desc: DOFDescriptorLike) -> DOFDescriptor:
 
 # {{{ type annotations
 
+DEFAULT_DOFDESC = DOFDescriptor()
+
 DiscretizationStages = (
         type[QBX_SOURCE_STAGE1]
         | type[QBX_SOURCE_STAGE2]

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -407,7 +407,6 @@ class DiscretizationProperty(Expression):
 
     def __post_init__(self) -> None:
         if not isinstance(self.dofdesc, DOFDescriptor):
-            breakpoint()
             warn("Passing a 'dofdesc' that is not a 'DOFDescriptor' to "
                  f"{type(self).__name__!r} is deprecated and will stop working "
                  "in 2025. Use 'as_dofdesc' to convert the descriptor.",
@@ -430,7 +429,7 @@ class IsShapeClass(DiscretizationProperty):
     # FIXME: this is added for backwards compatibility with pre-dataclass expressions
     def __init__(self, shape: mp.Shape, dofdesc: DOFDescriptorLike) -> None:
         object.__setattr__(self, "shape", shape)
-        super().__init__(dofdesc)
+        super().__init__(dofdesc)  # type: ignore[arg-type]
 
 
 @expr_dataclass()
@@ -450,14 +449,14 @@ class NodeCoordinateComponent(DiscretizationProperty):
     # FIXME: this is added for backwards compatibility with pre-dataclass expressions
     def __init__(self, ambient_axis: int, dofdesc: DOFDescriptorLike) -> None:
         object.__setattr__(self, "ambient_axis", ambient_axis)
-        super().__init__(dofdesc)
+        super().__init__(dofdesc)   # type: ignore[arg-type]
 
 
 def nodes(ambient_dim, dofdesc=None):
     """Return a :class:`pymbolic.geometric_algebra.MultiVector` of node
     locations.
     """
-
+    dofdesc = as_dofdesc(dofdesc)
     return MultiVector(
             make_obj_array([
                 NodeCoordinateComponent(i, dofdesc)
@@ -506,10 +505,9 @@ class NumReferenceDerivative(DiscretizationProperty):
                  dofdesc: DOFDescriptorLike) -> None:
         object.__setattr__(self, "ref_axes", ref_axes)
         object.__setattr__(self, "operand", operand)
-        super().__init__(dofdesc)
+        super().__init__(dofdesc)   # type: ignore[arg-type]
 
         if isinstance(self.ref_axes, int):
-            breakpoint()
             warn(f"Passing an 'int' as 'ref_axes' to {type(self).__name__!r} "
                  "is deprecated and will be removed in 2025. Pass the "
                  "well-formatted tuple '((ref_axes, 1),)' instead.",
@@ -535,6 +533,7 @@ def reference_jacobian(func, output_dim, dim, dofdesc=None):
     """Return a :class:`numpy.ndarray` representing the Jacobian of a vector function
     with respect to the reference coordinates.
     """
+    dofdesc = as_dofdesc(dofdesc)
     jac = np.zeros((output_dim, dim), object)
 
     for i in range(output_dim):
@@ -589,6 +588,7 @@ def area_element(ambient_dim, dim=None, dofdesc=None):
 
 
 def sqrt_jac_q_weight(ambient_dim, dim=None, dofdesc=None):
+    dofdesc = as_dofdesc(dofdesc)
     return cse(
             sqrt(
                 area_element(ambient_dim, dim, dofdesc)
@@ -602,6 +602,7 @@ def normal(ambient_dim, dim=None, dofdesc=None):
     # Don't be tempted to add a sign here. As it is, it produces
     # exterior normals for positively oriented curves and surfaces.
 
+    dofdesc = as_dofdesc(dofdesc)
     pder = (
             pseudoscalar(ambient_dim, dim, dofdesc)
             / area_element(ambient_dim, dim, dofdesc))
@@ -661,6 +662,7 @@ def second_fundamental_form(ambient_dim, dim=None, dofdesc=None):
     if not (ambient_dim == 3 and dim == 2):
         raise NotImplementedError("only available for surfaces in 3D")
 
+    dofdesc = as_dofdesc(dofdesc)
     r = nodes(ambient_dim, dofdesc=dofdesc).as_vector()
 
     # https://en.wikipedia.org/w/index.php?title=Second_fundamental_form&oldid=821047433#Classical_notation
@@ -1071,7 +1073,6 @@ class Interpolation(Expression):
 
     def __post_init__(self) -> None:
         if not isinstance(self.from_dd, DOFDescriptor):
-            breakpoint()
             warn("Passing a 'from_dd' that is not a 'DOFDescriptor' to "
                  f"{type(self).__name__!r} is deprecated and will stop working "
                  "in 2025. Use 'as_dofdesc' to convert the descriptor.",
@@ -1080,7 +1081,6 @@ class Interpolation(Expression):
             object.__setattr__(self, "from_dd", as_dofdesc(self.from_dd))
 
         if not isinstance(self.to_dd, DOFDescriptor):
-            breakpoint()
             warn("Passing a 'to_dd' that is not a 'DOFDescriptor' to "
                  f"{type(self).__name__!r} is deprecated and will stop working "
                  "in 2025. Use 'as_dofdesc' to convert the descriptor.",
@@ -1135,6 +1135,7 @@ class NodeMin(SingleScalarOperandExpression):
 def integral(ambient_dim, dim, operand, dofdesc=None):
     """A volume integral of *operand*."""
 
+    dofdesc = as_dofdesc(dofdesc)
     return NodeSum(
             area_element(ambient_dim, dim, dofdesc)
             * QWeight(dofdesc)
@@ -1171,7 +1172,6 @@ class SingleScalarOperandExpressionWithWhere(Expression):
 
     def __post_init__(self) -> None:
         if not isinstance(self.dofdesc, DOFDescriptor):
-            breakpoint()
             warn("Passing a 'dofdesc' that is not a 'DOFDescriptor' to "
                  f"{type(self).__name__!r} is deprecated and will stop working "
                  "in 2025. Use 'as_dofdesc' to convert the descriptor.",
@@ -1212,7 +1212,6 @@ class Ones(Expression):
 
     def __post_init__(self) -> None:
         if not isinstance(self.dofdesc, DOFDescriptor):
-            breakpoint()
             warn("Passing a 'dofdesc' that is not a 'DOFDescriptor' to "
                  f"{type(self).__name__!r} is deprecated and will stop working "
                  "in 2025. Use 'as_dofdesc' to convert the descriptor.",
@@ -1223,11 +1222,13 @@ class Ones(Expression):
 
 def ones_vec(dim, dofdesc=None):
     from pytools.obj_array import make_obj_array
-    return MultiVector(
-                make_obj_array(dim*[Ones(dofdesc)]))
+
+    dofdesc = as_dofdesc(dofdesc)
+    return MultiVector(make_obj_array(dim*[Ones(dofdesc)]))
 
 
 def area(ambient_dim, dim, dofdesc=None):
+    dofdesc = as_dofdesc(dofdesc)
     return cse(integral(ambient_dim, dim, Ones(dofdesc), dofdesc), "area",
             cse_scope.DISCRETIZATION)
 
@@ -1262,7 +1263,6 @@ class IterativeInverse(Expression):
 
     def __post_init__(self) -> None:
         if not isinstance(self.dofdesc, DOFDescriptor):
-            breakpoint()
             warn("Passing a 'dofdesc' that is not a 'DOFDescriptor' to "
                  f"{type(self).__name__!r} is deprecated and will stop working "
                  "in 2025. Use 'as_dofdesc' to convert the descriptor.",
@@ -1807,9 +1807,9 @@ def tangential_onb(ambient_dim, dim=None, dofdesc=None):
         q = avec
         for j in range(k):
             q = q - np.dot(avec, orth_pd_mat[:, j])*orth_pd_mat[:, j]
-        q = cse(q, "q%d" % k)
+        q = cse(q, f"q{k}")
 
-        orth_pd_mat[:, k] = cse(q/sqrt(np.sum(q**2)), "orth_pd_vec%d_" % k)
+        orth_pd_mat[:, k] = cse(q/sqrt(np.sum(q**2)), f"orth_pd_vec{k}_")
 
     # }}}
 
@@ -1835,7 +1835,8 @@ def tangential_to_xyz(tangential_vec, dofdesc=None):
 
 def project_to_tangential(xyz_vec, dofdesc=None):
     return tangential_to_xyz(
-            cse(xyz_to_tangential(xyz_vec, dofdesc), dofdesc))
+            cse(xyz_to_tangential(xyz_vec, dofdesc)),
+            dofdesc)
 
 
 def n_dot(vec, dofdesc=None):

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -90,11 +90,17 @@ associated with a :class:`~meshmode.discretization.Discretization`, then
 :class:`~pyopencl.array.Array` is used.
 
 .. autoclass:: Expression
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
 
 Diagnostics
 ^^^^^^^^^^^
 
 .. autoclass:: ErrorExpression
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
 
 .. _placeholders:
 
@@ -102,7 +108,12 @@ Placeholders
 ^^^^^^^^^^^^
 
 .. autoclass:: var
+
 .. autoclass:: SpatialConstant
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
+
 .. autofunction:: make_sym_mv
 .. autofunction:: make_sym_surface_mv
 
@@ -139,8 +150,21 @@ Functions
 Discretization properties
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
+.. autoclass:: DiscretizationProperty
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
+
 .. autoclass:: IsShapeClass
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
+
 .. autoclass:: QWeight
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
+
 .. autofunction:: nodes
 .. autofunction:: parametrization_derivative
 .. autofunction:: parametrization_derivative_matrix
@@ -162,28 +186,66 @@ Elementary numerics
 ^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: NumReferenceDerivative
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
+
 .. autoclass:: NodeSum
+    :undoc-members:
+    :members: mapper_method
+
 .. autoclass:: NodeMax
+    :undoc-members:
+    :members: mapper_method
+
 .. autoclass:: NodeMin
+    :undoc-members:
+    :members: mapper_method
+
 .. autoclass:: ElementwiseSum
+    :undoc-members:
+    :members: mapper_method
+
+.. autoclass:: ElementwiseMin
+    :undoc-members:
+    :members: mapper_method
+
 .. autoclass:: ElementwiseMax
+    :undoc-members:
+    :members: mapper_method
+
 .. autofunction:: integral
+
 .. autoclass:: Ones
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
+
 .. autofunction:: ones_vec
 .. autofunction:: area
 .. autofunction:: mean
+
 .. autoclass:: IterativeInverse
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
+
 
 Operators
 ^^^^^^^^^
 
 .. autoclass:: Interpolation
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
+
 .. autofunction:: interp
 
 Geometric Calculus (based on Geometric/Clifford Algebra)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autoclass:: Derivative
+    :undoc-members:
 
 Conventional Calculus
 ^^^^^^^^^^^^^^^^^^^^^
@@ -200,6 +262,10 @@ Layer potentials
 ^^^^^^^^^^^^^^^^
 
 .. autoclass:: IntG
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
+
 .. autofunction:: int_g_dsource
 .. autofunction:: int_g_vec
 
@@ -310,9 +376,7 @@ def array_to_tuple(ary):
 
 @expr_dataclass()
 class Expression(ExpressionBase):
-    """Bases: :class:`~pymbolic.primitives.Expression`.
-
-    A subclass of :class:`~pymbolic.primitives.Expression` for use with
+    """A subclass of :class:`pymbolic.primitives.Expression` for use with
     :mod:`pytential` mappers.
     """
 
@@ -338,7 +402,7 @@ class ErrorExpression(Expression):
     """The error message to raise when this expression is encountered."""
 
 
-def make_sym_mv(name, num_components):
+def make_sym_mv(name: str, num_components: int) -> MultiVector[Expression]:
     return MultiVector(make_sym_vector(name, num_components))
 
 
@@ -346,8 +410,8 @@ def make_sym_surface_mv(name, ambient_dim, dim, dofdesc=None):
     par_grad = parametrization_derivative_matrix(ambient_dim, dim, dofdesc)
 
     return sum(
-            var("%s%d" % (name, i))
-            * cse(MultiVector(vec), "tangent%d" % i, cse_scope.DISCRETIZATION)
+            var(f"{name}{i}")
+            * cse(MultiVector(vec), f"tangent{i}", cse_scope.DISCRETIZATION)
             for i, vec in enumerate(par_grad.T))
 
 
@@ -1128,17 +1192,26 @@ class SingleScalarOperandExpression(Expression):
 
 @expr_dataclass()
 class NodeSum(SingleScalarOperandExpression):
-    """Implements a global sum over all discretization nodes."""
+    """Bases: :class:`~pytential.symbolic.primitives.Expression`.
+
+    Implements a global sum over all discretization nodes.
+    """
 
 
 @expr_dataclass()
 class NodeMax(SingleScalarOperandExpression):
-    """Implements a global maximum over all discretization nodes."""
+    """Bases: :class:`~pytential.symbolic.primitives.Expression`.
+
+    Implements a global maximum over all discretization nodes.
+    """
 
 
 @expr_dataclass()
 class NodeMin(SingleScalarOperandExpression):
-    """Implements a global minimum over all discretization nodes."""
+    """Bases: :class:`~pytential.symbolic.primitives.Expression`.
+
+    Implements a global minimum over all discretization nodes.
+    """
 
 
 def integral(ambient_dim, dim, operand, dofdesc=None):
@@ -1191,21 +1264,27 @@ class SingleScalarOperandExpressionWithWhere(Expression):
 
 @expr_dataclass()
 class ElementwiseSum(SingleScalarOperandExpressionWithWhere):
-    """Returns a vector of DOFs with all entries on each element set
+    """Bases: :class:`~pytential.symbolic.primitives.Expression`.
+
+    Returns a vector of DOFs with all entries on each element set
     to the sum of DOFs on that element.
     """
 
 
 @expr_dataclass()
 class ElementwiseMin(SingleScalarOperandExpressionWithWhere):
-    """Returns a vector of DOFs with all entries on each element set
+    """Bases: :class:`~pytential.symbolic.primitives.Expression`.
+
+    Returns a vector of DOFs with all entries on each element set
     to the minimum of DOFs on that element.
     """
 
 
 @expr_dataclass()
 class ElementwiseMax(SingleScalarOperandExpressionWithWhere):
-    """Returns a vector of DOFs with all entries on each element set
+    """Bases: :class:`~pytential.symbolic.primitives.Expression`.
+
+    Returns a vector of DOFs with all entries on each element set
     to the maximum of DOFs on that element.
     """
 
@@ -1281,6 +1360,15 @@ class IterativeInverse(Expression):
 
 
 class Derivative(DerivativeBase):
+    """A symbolic derivative.
+
+    This mechanism cannot be used to take more than one derivative at a time.
+
+    .. automethod:: __call__
+    .. automethod:: dnabla
+    .. automethod:: resolve
+    """
+
     @property
     def nabla(self):
         raise ValueError("Derivative.nabla should not be used"
@@ -1364,7 +1452,7 @@ class IntG(Expression):
     r"""
     .. math::
 
-        \int_\Gamma T (\sum S_k[G](x-y) \sigma_k(y)) dS_y
+        \int_\Gamma T \left[\sum S_k[G](x-y) \sigma_k(y)\right] \,\mathrm{d} S_y
 
     where :math:`\sigma_k` is the k-th *density*, :math:`G` is a Green's
     function, :math:`S_k` are source derivative operators and :math:`T` is a

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -89,6 +89,8 @@ associated with a :class:`~meshmode.discretization.Discretization`, then
 :class:`~meshmode.dof_array.DOFArray` is used and otherwise
 :class:`~pyopencl.array.Array` is used.
 
+.. autoclass:: Expression
+
 Diagnostics
 ^^^^^^^^^^^
 
@@ -228,6 +230,8 @@ Pretty-printing expressions
 """
 
 __all__ = (
+    "Expression",
+
     "ErrorExpression",
 
     "var", "SpatialConstant", "make_sym_mv", "make_sym_surface_mv",
@@ -306,6 +310,12 @@ def array_to_tuple(ary):
 
 @expr_dataclass()
 class Expression(ExpressionBase):
+    """Bases: :class:`~pymbolic.primitives.Expression`.
+
+    A subclass of :class:`~pymbolic.primitives.Expression` for use with
+    :mod:`pytential` mappers.
+    """
+
     def make_stringifier(self, originating_stringifier=None):
         from pytential.symbolic.mappers import StringifyMapper
         return StringifyMapper()
@@ -1405,15 +1415,21 @@ class IntG(Expression):
     fail if no QBX center is found. To allow potential evaluation at the target
     to succeeds even if no applicable QBX center is found use ``±2``.
     """
-    source: DOFDescriptor = field(default_factory=lambda: EMPTY_DESCRIPTOR)
+
+    # pylint: disable-next=invalid-field-call
+    source: DOFDescriptor = field(default_factory=lambda: DEFAULT_DOFDESC)
     """The symbolic name of the source discretization. This name is bound to a
     concrete :class:`~pytential.source.LayerPotentialSourceBase`
     by :func:`pytential.bind`.
     """
-    target: DOFDescriptor = field(default_factory=lambda: EMPTY_DESCRIPTOR)
+
+    # pylint: disable-next=invalid-field-call
+    target: DOFDescriptor = field(default_factory=lambda: DEFAULT_DOFDESC)
     """The symbolic name of the set of targets. This name gets assigned to a
     concrete target set by :func:`pytential.bind`.
     """
+
+    # pylint: disable-next=invalid-field-call
     kernel_arguments: dict[str, Operand] = field(default_factory=dict)
     """A dictionary mapping named :class:`~sumpy.kernel.Kernel` arguments
     (see :meth:`~sumpy.kernel.Kernel.get_args` and
@@ -1475,7 +1491,7 @@ class IntG(Expression):
             for karg in (kernel.get_args() + kernel.get_source_args()):
                 kernel_arg_names.add(karg.loopy_arg.name)
 
-        provided_arg_names = set(self.kernel_arguments.keys())
+        provided_arg_names = set(self.kernel_arguments.keys())  # pylint: disable=no-member
         missing_args = kernel_arg_names - provided_arg_names
         if missing_args:
             raise ValueError(

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -20,7 +20,6 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from collections.abc import Sequence
 from dataclasses import field
 from warnings import warn
 from functools import partial
@@ -1350,179 +1349,183 @@ def hashable_kernel_args(kernel_arguments):
     return tuple(hashable_args)
 
 
+@expr_dataclass(hash=False)
 class IntG(Expression):
     r"""
     .. math::
 
-        \int_\Gamma T (\sum S_k G(x-y) \sigma_k(y)) dS_y
+        \int_\Gamma T (\sum S_k[G](x-y) \sigma_k(y)) dS_y
 
     where :math:`\sigma_k` is the k-th *density*, :math:`G` is a Green's
     function, :math:`S_k` are source derivative operators and :math:`T` is a
     target derivative operator.
 
-    .. attribute:: target_kernel
-    .. attribute:: source_kernels
-    .. attribute:: densities
-    .. attribute:: qbx_forced_limit
-    .. attribute:: kernel_arguments
+    .. autoattribute:: target_kernel
+    .. autoattribute:: source_kernels
+    .. autoattribute:: densities
+    .. autoattribute:: qbx_forced_limit
+    .. autoattribute:: source
+    .. autoattribute:: target
+    .. autoattribute:: kernel_arguments
     """
 
-    init_arg_names = ("target_kernel", "source_kernels", "densities",
-                      "qbx_forced_limit", "source", "target", "kernel_arguments")
+    target_kernel: Kernel
+    """An instance of :class:`~sumpy.kernel.Kernel` with only target dervatives
+    attached. This represents the target derivative operator :math:`T` above.
 
-    def __init__(self,
-                 target_kernel: Kernel,
-                 source_kernels: Sequence[Kernel],
-                 densities: Sequence[Expression],
-                 qbx_forced_limit: QBXForcedLimit,
-                 source: DOFDescriptorLike = None,
-                 target: DOFDescriptorLike = None,
-                 kernel_arguments: (
-                     dict[str, Any]
-                     | Sequence[tuple[str, Any]]
-                     | None) = None,
-                 **kwargs: Any) -> None:
-        """*target_derivatives* and later arguments should be considered
-        keyword-only.
+    Note that the term ``target_kernel`` is bad as it's not a kernel and merely
+    represents a target derivative operator. This name will change once :mod:`sumpy`
+    properly supports derivative operators. This also means that the user has to
+    make sure that base kernels of all the kernels passed are the same.
+    """
+    source_kernels: tuple[Kernel, ...]
+    """A tuple of instances of :class:`~sumpy.kernel.Kernel` with only source
+    derivatives attached. k-th elements represents the k-th source derivative
+    operator above.
+    """
+    densities: tuple[Expression, ...]
+    """A tuple of density expressions. Length of this tuple must match the length
+    of the *source_kernels* arguments.
+    """
+    qbx_forced_limit: QBXForcedLimit
+    """Limit used for the QBX expansions. Can take one of the values
 
-        :arg source_kernels: a tuple of instances of :class:`sumpy.kernel.Kernel`
-            with only source derivatives attached. k-th elements represents the
-            k-th source derivative operator above.
-        :arg target_kernel: an instance of :class:`sumpy.kernel.Kernel` with only
-            target dervatives attached. This represents the target derivative
-            operator :math:`T` above. Note that the term ``target_kernel`` is
-            bad as it's not a kernel and merely represents a target derivative
-            operator. This name will change once :mod:`sumpy` properly
-            supports derivative operators. This also means that the user has to
-            make sure that base kernels of all the kernels passed are the same.
-        :arg densities: a tuple of density expressions. Length of this tuple
-            must match the length of the source_kernels arguments.
-        :arg qbx_forced_limit: +1 if the output is required to originate from a
-            QBX center on the "+" side of the boundary. -1 for the other side.
-            Evaluation at a target with a value of +/- 1 in *qbx_forced_limit*
-            will fail if no QBX center is found.
+    * *None*: may be used to avoid expressing a side preference for close
+      evaluation.
+    * ``+1``: if the output is required to originate from a QBX center on the "+"
+      side of the boundary.
+    * ``-1``: for the "-" side.
+    * ``'avg'``: may be used as a shorthand to evaluate this potential as an
+      average of the ``+1`` and the ``-1`` value.
+    * ``+2`` may be used to *allow* evaluation QBX center on the "+" side of the
+      (but disallow evaluation using a center on the "-" side).
+    * ``-2``: for the "-" side.
 
-            +2 may be used to *allow* evaluation QBX center on the "+" side of the
-            (but disallow evaluation using a center on the "-" side). Potential
-            evaluation at the target still succeeds if no applicable QBX center
-            is found. (-2 for the analogous behavior on the "-" side.)
+    Evaluation at a target with a value of ``±1`` in *qbx_forced_limit* will
+    fail if no QBX center is found. To allow potential evaluation at the target
+    to succeeds even if no applicable QBX center is found use ``±2``.
+    """
+    source: DOFDescriptor = field(default_factory=lambda: EMPTY_DESCRIPTOR)
+    """The symbolic name of the source discretization. This name is bound to a
+    concrete :class:`~pytential.source.LayerPotentialSourceBase`
+    by :func:`pytential.bind`.
+    """
+    target: DOFDescriptor = field(default_factory=lambda: EMPTY_DESCRIPTOR)
+    """The symbolic name of the set of targets. This name gets assigned to a
+    concrete target set by :func:`pytential.bind`.
+    """
+    kernel_arguments: dict[str, Operand] = field(default_factory=dict)
+    """A dictionary mapping named :class:`~sumpy.kernel.Kernel` arguments
+    (see :meth:`~sumpy.kernel.Kernel.get_args` and
+    :meth:`~sumpy.kernel.Kernel.get_source_args`) to expressions that determine
+    them.
+    """
 
-            *None* may be used to avoid expressing a side preference for close
-            evaluation.
+    def __post_init__(self) -> None:
+        if self.qbx_forced_limit not in {-1, +1, -2, +2, "avg", None}:
+            raise ValueError(
+                f"Invalid value for 'qbx_forced_limit': {self.qbx_forced_limit}"
+            )
 
-            ``'avg'`` may be used as a shorthand to evaluate this potential
-            as an average of the ``+1`` and the ``-1`` value.
+        if not isinstance(self.source_kernels, tuple):
+            warn(f"'source_kernels' is not tuple ({type(self.source_kernels)}). "
+                 "Passing a different type is deprecated and will stop working in "
+                 "2025.", DeprecationWarning, stacklevel=2)
 
-        :arg kernel_arguments: A dictionary mapping named
-            :class:`sumpy.kernel.Kernel` arguments
-            (see :meth:`sumpy.kernel.Kernel.get_args`
-            and :meth:`sumpy.kernel.Kernel.get_source_args`)
-            to expressions that determine them
+            object.__setattr__(self, "source_kernels", tuple(self.source_kernels))
 
-        :arg source: The symbolic name of the source discretization. This name
-            is bound to a concrete :class:`pytential.source.LayerPotentialSourceBase`
-            by :func:`pytential.bind`.
+        if not isinstance(self.densities, tuple):
+            warn(f"'densities' is not tuple ({type(self.densities)}). "
+                 "Passing a different type is deprecated and will stop working in "
+                 "2025.", DeprecationWarning, stacklevel=2)
 
-        :arg target: The symbolic name of the set of targets. This name gets
-            assigned to a concrete target set by :func:`pytential.bind`.
+            object.__setattr__(self, "densities", tuple(self.densities))
 
-        *kwargs* has the same meaning as *kernel_arguments* can be used as a
-        more user-friendly interface.
-        """
+        if not isinstance(self.source, DOFDescriptor):
+            warn("Passing a 'source' descriptor that is not a 'DOFDescriptor' to "
+                 f"{type(self).__name__!r} is deprecated and will stop working "
+                 "in 2025. Use 'as_dofdesc' to convert the descriptor.",
+                 DeprecationWarning, stacklevel=2)
 
-        if kernel_arguments is None:
-            kernel_arguments = {}
+            object.__setattr__(self, "source", as_dofdesc(self.source))
 
-        if not isinstance(kernel_arguments, dict):
-            kernel_arguments = dict(kernel_arguments)
+        if not isinstance(self.target, DOFDescriptor):
+            warn("Passing a 'target' descriptor that is not a 'DOFDescriptor' to "
+                 f"{type(self).__name__!r} is deprecated and will stop working "
+                 "in 2025. Use 'as_dofdesc' to convert the descriptor.",
+                 DeprecationWarning, stacklevel=2)
 
-        if qbx_forced_limit not in [-1, +1, -2, +2, "avg", None]:
-            raise ValueError("invalid value (%s) of qbx_forced_limit"
-                    % qbx_forced_limit)
+            object.__setattr__(self, "target", as_dofdesc(self.target))
 
-        source_kernels = tuple(source_kernels)
-        densities = tuple(densities)
-        kernel_arg_names = set()
+        if not isinstance(self.kernel_arguments, dict):
+            warn(f"'kernel_arguments' is not a dict ({type(self.kernel_arguments)}). "
+                 "Passing a different type is deprecated and will stop being "
+                 "supported in 2025.", DeprecationWarning, stacklevel=2)
 
-        for kernel in (*source_kernels, target_kernel):
-            for karg in (kernel.get_args() + kernel.get_source_args()):
-                kernel_arg_names.add(karg.loopy_arg.name)
+            kernel_arguments = self.kernel_arguments if self.kernel_arguments else {}
+            object.__setattr__(self, "kernel_arguments", dict(kernel_arguments))
 
         from pytools import single_valued
 
-        single_valued(kernel.get_base_kernel() for
-                kernel in (*source_kernels, target_kernel))
+        kernels = (*self.source_kernels, self.target_kernel)
+        single_valued(kernel.get_base_kernel() for kernel in kernels)
 
-        kernel_arguments = kernel_arguments.copy()
-        if kwargs:
-            for name, val in kwargs.items():
-                if name in kernel_arguments:
-                    raise ValueError("'%s' already set in kernel_arguments"
-                            % name)
+        kernel_arg_names = set()
+        for kernel in kernels:
+            for karg in (kernel.get_args() + kernel.get_source_args()):
+                kernel_arg_names.add(karg.loopy_arg.name)
 
-                if name not in kernel_arg_names:
-                    raise TypeError("'%s' not recognized as kernel argument"
-                            % name)
-
-                kernel_arguments[name] = val
-
-        provided_arg_names = set(kernel_arguments.keys())
+        provided_arg_names = set(self.kernel_arguments.keys())
         missing_args = kernel_arg_names - provided_arg_names
         if missing_args:
-            raise TypeError("kernel argument(s) '%s' not supplied"
-                    % ", ".join(missing_args))
+            raise ValueError(
+                "Kernel argument(s) not supplied: '{}'".format(", ".join(missing_args))
+            )
 
-        extraneous_args = provided_arg_names - kernel_arg_names
+        # FIXME: this check is clearly wrong :(
+        extra_args = provided_arg_names - kernel_arg_names
         if missing_args:
-            raise TypeError("kernel arguments '%s' not recognized"
-                    % ", ".join(extraneous_args))
+            raise ValueError(
+                "Kernel argument(s) not recognized: '{}'".format(", ".join(extra_args))
+            )
 
-        self.target_kernel = target_kernel
-        self.source_kernels = source_kernels
-        self.densities = tuple(densities)
-        self.qbx_forced_limit = qbx_forced_limit
-        self.source = as_dofdesc(source)
-        self.target = as_dofdesc(target)
-        self.kernel_arguments = kernel_arguments
+    def copy(self, **kwargs) -> "IntG":
+        warn(f"'{type(self).__name__}.copy' is deprecated and will be removed in "
+             f"2025. {type(self)} is a dataclass now and can use "
+             "'dataclasses.replace'.", DeprecationWarning, stacklevel=2)
 
-    def copy(self, target_kernel=None, source_kernels=None, densities=None,
-            qbx_forced_limit=_NoArgSentinel,
-            source=_NoArgSentinel, target=_NoArgSentinel,
-            kernel_arguments=None):
-        if target_kernel is None:
-            target_kernel = self.target_kernel
+        from dataclasses import replace
+        return replace(self, **kwargs)
 
-        if source_kernels is None:
-            source_kernels = self.source_kernels
+    def __eq__(self, other: Any) -> bool:
+        if self is other:
+            return True
+        if self.__class__ is not other.__class__:
+            return False
+        if hash(self) != hash(other):
+            return False
 
-        if densities is None:
-            densities = self.densities
+        return (
+            self.__class__ == other.__class__
+            and self.target_kernel == other.target_kernel
+            and self.source_kernels == other.source_kernels
+            and self.densities == other.densities
+            and self.source == other.source
+            and self.target == other.target
+            and (
+                hashable_kernel_args(self.kernel_arguments)
+                == hashable_kernel_args(other.kernel_arguments))
+            )
 
-        if kernel_arguments is None:
-            kernel_arguments = self.kernel_arguments
-
-        if qbx_forced_limit is _NoArgSentinel:
-            qbx_forced_limit = self.qbx_forced_limit
-
-        source = self.source if source is _NoArgSentinel else as_dofdesc(source)
-        target = self.target if target is _NoArgSentinel else as_dofdesc(target)
-        return type(self)(target_kernel, source_kernels, densities,
-                          qbx_forced_limit=qbx_forced_limit,
-                          source=source,
-                          target=target,
-                          kernel_arguments=kernel_arguments)
-
-    def __getinitargs__(self):
-        return (self.target_kernel, self.source_kernels, self.densities,
-                self.qbx_forced_limit, self.source, self.target,
-                hashable_kernel_args(self.kernel_arguments))
-
-    def __setstate__(self, state):
-        # Overwrite pymbolic.Expression.__setstate__
-        assert len(self.init_arg_names) == len(state), type(self)
-        self.__init__(*state)
-
-    mapper_method = "map_int_g"
+    def __hash__(self) -> int:
+        return hash((
+            self.target_kernel,
+            self.source_kernels,
+            self.densities,
+            self.qbx_forced_limit,
+            self.source, self.target,
+            hashable_kernel_args(self.kernel_arguments)
+            ))
 
 
 _DIR_VEC_NAME = "dsource_vec"
@@ -1576,17 +1579,10 @@ def int_g_dsource(ambient_dim, dsource, kernel, density,
     r"""
     .. math::
 
-        \int_\Gamma \operatorname{dsource} \dot \nabla_y
-            \dot g(x-y) \sigma(y) dS_y
+        \int_\Gamma \operatorname{dsource} \dot \nabla_y G(x-y) \sigma(y) dS_y
 
-    where :math:`\sigma` is *density*, and
-    *dsource*, a multivector.
-    Note that the first product in the integrand
-    is a geometric product.
-
-    .. attribute:: dsource
-
-        A :class:`pymbolic.geometric_algebra.MultiVector`.
+    where :math:`\sigma` is *density* and *dsource* is a multivector.
+    Note that the first product in the integrand is a geometric product.
     """
 
     if kernel_arguments is None:
@@ -1648,13 +1644,23 @@ def int_g_vec(kernel, density, qbx_forced_limit, source=None, target=None,
     txr = TargetTransformationRemover()
 
     target_kernel = sxr(kernel)
-    source_kernels = [txr(kernel)]
+    source_kernels = (txr(kernel),)
+
+    if kernel_arguments is None:
+        kernel_arguments = {}
+
+    if kwargs is not None:
+        kernel_arguments = {**kernel_arguments, **kwargs}
 
     def make_op(operand_i):
-        return IntG(target_kernel=target_kernel, densities=[operand_i],
+        return IntG(
+            target_kernel=target_kernel,
             source_kernels=source_kernels,
-            qbx_forced_limit=qbx_forced_limit, source=source, target=target,
-            kernel_arguments=kernel_arguments, **kwargs)
+            densities=(operand_i,),
+            qbx_forced_limit=qbx_forced_limit,
+            source=as_dofdesc(source),
+            target=as_dofdesc(target),
+            kernel_arguments=kernel_arguments)
 
     if isinstance(density, np.ndarray | MultiVector):
         return componentwise(make_op, density)

--- a/test/test_cost_model.py
+++ b/test/test_cost_model.py
@@ -336,7 +336,7 @@ def test_timing_data_gathering(ctx_factory):
     cl_ctx = ctx_factory()
     queue = cl.CommandQueue(cl_ctx,
             properties=cl.command_queue_properties.PROFILING_ENABLE)
-    actx = PyOpenCLArrayContext(queue, force_device_scalars=True)
+    actx = PyOpenCLArrayContext(queue)
 
     lpot_source = get_lpot_source(actx, 2)
     places = GeometryCollection(lpot_source)


### PR DESCRIPTION
Updates things to use `expr_dataclass` and fixes various deprecation warnings.

Needs:
- [X] https://github.com/inducer/pymbolic/pull/150
- [X] https://github.com/inducer/sumpy/pull/217
- [X] https://github.com/inducer/loopy/pull/868