### PR TITLE
Improve compat with pre-dataclass expressions

### DIFF
--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -61,7 +61,7 @@ def rec_int_g_arguments(mapper, expr):
             name: mapper.rec(arg) for name, arg in expr.kernel_arguments.items()
             }
 
-    changed = (
+    changed = not (
             all(d is orig for d, orig in zip(densities, expr.densities, strict=True))
             and all(
                 arg is orig for arg, orig in zip(

--- a/test/test_symbolic.py
+++ b/test/test_symbolic.py
@@ -500,7 +500,7 @@ def test_mapper_int_g_term_collector(op_name, k=0):
         raise ValueError(f"unknown operator name: {op_name}")
 
     from pytential.symbolic.mappers import flatten
-    assert expr_only_intgs == flatten(expected_expr)
+    assert flatten(expr_only_intgs) == flatten(expected_expr)
 
 # }}}
 


### PR DESCRIPTION
Mostly adds back some `dofdesc=None` default constructors found during merging main into #162.