### PR TITLE
ruff: disable rule RUF052

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ extend-ignore = [
     "N806", # variable name should be lowercase
     "RUF012", # ClassVar for mutable class attributes
     "RUF022", # __all__ is not sorted
+    "RUF052", # underscored variable is used
     "UP031", # use f-strings instead of %
     "UP032", # use f-strings instead of .format
 ]


### PR DESCRIPTION
RUF052 seems to complain about underscore variables in function arguments. We use that quite a bit to denote "useful, but private, don't depend on this" arguments, so it seemed like a good idea to disable it.