### PR TITLE
Bump tolerance for skeletonization test

### DIFF
--- a/pytential/linalg/utils.py
+++ b/pytential/linalg/utils.py
@@ -326,7 +326,10 @@ def make_flat_cluster_diag(
 # {{{ interpolative decomposition
 
 def interp_decomp(
-        A: np.ndarray, *, rank: int | None, eps: float | None,
+        A: np.ndarray, *,
+        rank: int | None,
+        eps: float | None,
+        rng: np.random.Generator | None = None,
         ) -> tuple[int, np.ndarray, np.ndarray]:
     """Wrapper for :func:`~scipy.linalg.interpolative.interp_decomp` that
     always has the same output signature.
@@ -337,11 +340,21 @@ def interp_decomp(
     if rank is not None and eps is not None:
         raise ValueError("providing both 'rank' and 'eps' is not supported")
 
+    from scipy import __version__
+
+    kwargs = {}
+    if __version__ >= "1.15.0":
+        if rng is None:
+            rng = np.random.default_rng()
+
+        kwargs["rng"] = rng
+
     import scipy.linalg.interpolative as sli
+
     if rank is None:
-        k, idx, proj = sli.interp_decomp(A, eps)
+        k, idx, proj = sli.interp_decomp(A, eps, **kwargs)
     else:
-        idx, proj = sli.interp_decomp(A, rank)
+        idx, proj = sli.interp_decomp(A, rank, **kwargs)
         k = rank
 
     interp = sli.reconstruct_interp_matrix(idx, proj)

--- a/pytential/symbolic/matrix.py
+++ b/pytential/symbolic/matrix.py
@@ -120,7 +120,7 @@ class MatrixBuilderBase(EvaluationMapperBase):
             that the builder is evaluating.
         :arg other_dep_exprs: symbolic expressions for the remaining input
             block columns.
-        :arg dep_discr: a concerete :class:`~meshmode.discretization.Discretization`
+        :arg dep_discr: a concrete :class:`~meshmode.discretization.Discretization`
             for the given *dep_expr*.
         :arg places: a :class:`~pytential.collection.GeometryCollection`
             for all the sources and targets the builder is expected to

--- a/test/test_linalg_skeletonization.py
+++ b/test/test_linalg_skeletonization.py
@@ -147,9 +147,12 @@ def test_skeletonize_symbolic(actx_factory, case, visualize=False):
 
     from pytential.linalg.skeletonization import (
             _skeletonize_block_by_proxy_with_mats)
+
+    rng = np.random.default_rng(42)
     _skeletonize_block_by_proxy_with_mats(
         actx, 0, 0, places, proxy_generator, wrangler, tgt_src_index,
-        id_eps=1.0e-8
+        id_eps=1.0e-8,
+        rng=rng,
     )
 
 # }}}
@@ -161,6 +164,7 @@ def test_skeletonize_symbolic(actx_factory, case, visualize=False):
 def run_skeletonize_by_proxy(actx, case, resolution,
                              places=None, mat=None,
                              ctol=None, rtol=None,
+                             rng=None,
                              suffix="", visualize=False):
     from pytools import ProcessTimer
 
@@ -238,7 +242,8 @@ def run_skeletonize_by_proxy(actx, case, resolution,
         skeleton = _skeletonize_block_by_proxy_with_mats(
                 actx, 0, 0, places, proxy_generator, wrangler, tgt_src_index,
                 id_eps=case.id_eps,
-                max_particles_in_box=case.max_particles_in_box)
+                max_particles_in_box=case.max_particles_in_box,
+                rng=rng)
 
     logger.info("[time] skeletonization by proxy: %s", p)
 
@@ -359,7 +364,9 @@ def test_skeletonize_by_proxy(actx_factory, case, visualize=False):
     """
 
     import scipy.linalg.interpolative as sli
+
     sli.seed(42)
+    rng = np.random.default_rng(42)
 
     actx = actx_factory()
 
@@ -374,6 +381,7 @@ def test_skeletonize_by_proxy(actx_factory, case, visualize=False):
         ctol=10,
         # FIXME: why is the 3D error so large?
         rtol=10**case.ambient_dim,
+        rng=rng,
         visualize=visualize)
 
 # }}}
@@ -406,7 +414,9 @@ def test_skeletonize_by_proxy_convergence(
     (the ID tolerance).
     """
     import scipy.linalg.interpolative as sli
+
     sli.seed(42)
+    rng = np.random.default_rng(42)
 
     actx = actx_factory()
 
@@ -440,7 +450,7 @@ def test_skeletonize_by_proxy_convergence(
         case = replace(case, id_eps=id_eps[i], weighted_proxy=weighted)
         rec_error[i], (places, mat) = run_skeletonize_by_proxy(
             actx, case, r, places=places, mat=mat,
-            suffix=f"{suffix}_{i:04d}", visualize=False)
+            suffix=f"{suffix}_{i:04d}", rng=rng, visualize=False)
 
         was_zero = rec_error[i] == 0.0
         eoc.add_data_point(id_eps[i], rec_error[i])

--- a/test/test_linalg_skeletonization.py
+++ b/test/test_linalg_skeletonization.py
@@ -371,7 +371,7 @@ def test_skeletonize_by_proxy(actx_factory, case, visualize=False):
 
     run_skeletonize_by_proxy(
         actx, case, case.resolutions[0],
-        ctol=6,
+        ctol=10,
         # FIXME: why is the 3D error so large?
         rtol=10**case.ambient_dim,
         visualize=visualize)


### PR DESCRIPTION
This should fix the new failures. As far as I can tell, this is due to scipy 1.15 having a rewritten `interp_decomp` implementation.
```
>               assert tgt_error < ctol * case.id_eps
E               AssertionError: assert np.float64(7.672159794924751e-08) < (6 * 1e-08)
E                +  where 1e-08 = TorusTestCase(name='torus', ambient_dim=3, knl_class_or_helmholtz_k=0, knl_kwargs={}, bc_type='dirichlet', side=-1, qb...ighted_proxy=None, proxy_source_cluster_builder=None, proxy_target_cluster_builder=None, neighbor_cluster_builder=None).id_eps
```