### PR TITLE
Port to new obj_array functions

### DIFF
--- a/experiments/poisson.py
+++ b/experiments/poisson.py
@@ -12,7 +12,7 @@ from meshmode.discretization.poly_element import \
 from meshmode.discretization.visualization import make_visualizer
 
 from pytential import bind, sym, norm  # noqa
-from pytools.obj_array import make_obj_array
+from pytools import obj_array
 
 import pytential.symbolic.primitives as p
 
@@ -196,7 +196,7 @@ def main():
                     p.area_element(mesh.ambient_dim, mesh.dim))
                 (queue)).get())
 
-    centers = make_obj_array([ci.copy().reshape(vol_discr.nnodes) for ci in targets])
+    centers = obj_array.new_1d([ci.copy().reshape(vol_discr.nnodes) for ci in targets])
     centers[2][:] = center_dist
 
     print(center_dist)

--- a/experiments/qbx-tangential-deriv-jump.py
+++ b/experiments/qbx-tangential-deriv-jump.py
@@ -34,10 +34,10 @@ def main():
     qbx = QBXLayerPotentialSource(density_discr, 4*target_order,
             qbx_order, fmm_order=False)
 
-    from pytools.obj_array import join_fields
+    from pytools import obj_array
     sig_sym = sym.var("sig")
     knl = LaplaceKernel(2)
-    op = join_fields(
+    op = obj_array.flat(
             sym.tangential_derivative(mesh.ambient_dim,
                 sym.D(knl, sig_sym, qbx_forced_limit=+1)).as_scalar(),
             sym.tangential_derivative(mesh.ambient_dim,

--- a/experiments/stokes-2d-interior.py
+++ b/experiments/stokes-2d-interior.py
@@ -33,8 +33,8 @@ def main(nelements):
     logging.basicConfig(level=logging.INFO)
 
     def get_obj_array(obj_array):
-        from pytools.obj_array import make_obj_array
-        return make_obj_array([
+        from pytools import obj_array
+        return obj_array.new_1d([
                 ary.get()
                 for ary in obj_array
                 ])
@@ -72,7 +72,6 @@ def main(nelements):
 
     from sumpy.kernel import LaplaceKernel
     from pytential.symbolic.stokes import StressletWrapper
-    from pytools.obj_array import make_obj_array
     dim=2
     cse = sym.cse
 

--- a/experiments/two-domain-helmholtz.py
+++ b/experiments/two-domain-helmholtz.py
@@ -27,7 +27,7 @@ import pyopencl as cl
 import pyopencl.array  # noqa
 import pyopencl.clmath  # noqa
 
-from pytools.obj_array import make_obj_array
+from pytools import obj_array
 
 from meshmode.discretization import Discretization
 from meshmode.discretization.poly_element import \
@@ -105,7 +105,7 @@ def main():
     bound_pde_op = bind(qbx, pde_op.operator(op_unknown_sym))
 
     # in inner domain
-    sources_1 = make_obj_array(list(np.array([
+    sources_1 = obj_array.new_1d(list(np.array([
         [-1.5, 0.5]
         ]).T.copy()))
     strengths_1 = np.array([1])

--- a/pytential/linalg/direct_solver_symbolic.py
+++ b/pytential/linalg/direct_solver_symbolic.py
@@ -20,7 +20,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 """
 
-from pytools.obj_array import make_obj_array
+from pytools import obj_array
 
 from pytential.symbolic.mappers import (
         IdentityMapper, OperatorCollector, LocationTagger)
@@ -44,7 +44,7 @@ class PROXY_SKELETONIZATION_TARGET:             # noqa: N801
 
 def prepare_expr(places, exprs, auto_where=None):
     from pytential.symbolic.execution import _prepare_expr
-    return make_obj_array([
+    return obj_array.new_1d([
         _prepare_expr(places, expr, auto_where=auto_where)
         for expr in exprs])
 
@@ -60,7 +60,7 @@ def prepare_proxy_expr(places, exprs, auto_where=None):
 
         return expr
 
-    return make_obj_array([_prepare_expr(expr) for expr in exprs])
+    return obj_array.new_1d([_prepare_expr(expr) for expr in exprs])
 
 # }}}
 

--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -485,10 +485,9 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
                     calibration_params
                 )
 
-            from pytools.obj_array import obj_array_vectorize
-            from functools import partial
+            from pytools import obj_array
             return (
-                    obj_array_vectorize(
+                    obj_array.vectorize(
                         partial(wrangler.finalize_potentials,
                             template_ary=strengths[0]),
                         wrangler.full_output_zeros(strengths[0])),
@@ -518,7 +517,6 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
 
     @memoize_method
     def _tree_indep_data_for_wrangler(self, source_kernels, target_kernels):
-        from functools import partial
         base_kernel = single_valued(kernel.get_base_kernel() for
             kernel in source_kernels)
         mpole_expn_class = \

--- a/pytential/qbx/fmm.py
+++ b/pytential/qbx/fmm.py
@@ -143,8 +143,8 @@ non_qbx_box_target_lists`),
 
         nqbtl = self.geo_data.non_qbx_box_target_lists()
 
-        from pytools.obj_array import make_obj_array
-        return make_obj_array([
+        from pytools import obj_array
+        return obj_array.new_1d([
                 cl.array.zeros(
                     template_ary.queue,
                     nqbtl.nfiltered_targets,
@@ -596,8 +596,8 @@ def drive_fmm(expansion_wrangler, src_weight_vecs, timing_data=None):
         # potential back into a CL array.
         return wrangler.finalize_potentials(x[tree.sorted_target_ids], template_ary)
 
-    from pytools.obj_array import obj_array_vectorize
-    result = obj_array_vectorize(
+    from pytools import obj_array
+    result = obj_array.vectorize(
             reorder_and_finalize_potentials, all_potentials_in_tree_order)
 
     # }}}

--- a/pytential/qbx/fmmlib.py
+++ b/pytential/qbx/fmmlib.py
@@ -209,16 +209,16 @@ class QBXFMMLibExpansionWrangler(FMMLibExpansionWrangler):
 
         nqbtl = self.geo_data.non_qbx_box_target_lists()
 
-        from pytools.obj_array import make_obj_array
-        return make_obj_array([
+        from pytools import obj_array
+        return obj_array.new_1d([
                 np.zeros(nqbtl.nfiltered_targets, self.tree_indep.dtype)
                 for k in self.tree_indep.outputs])
 
     def full_output_zeros(self, template_ary):
         """This includes QBX and non-QBX targets."""
 
-        from pytools.obj_array import make_obj_array
-        return make_obj_array([
+        from pytools import obj_array
+        return obj_array.new_1d([
                 np.zeros(self.tree.ntargets, self.tree_indep.dtype)
                 for k in self.tree_indep.outputs])
 

--- a/pytential/symbolic/compiler.py
+++ b/pytential/symbolic/compiler.py
@@ -394,7 +394,7 @@ def _get_next_step(
 
     # {{{ make sure results do not get discarded
 
-    from pytools.obj_array import obj_array_vectorize
+    from pytools import obj_array
 
     from pytential.symbolic.mappers import DependencyMapper
     dm = DependencyMapper(composite_leaves=False)
@@ -409,7 +409,7 @@ def _get_next_step(
             assert isinstance(var, Variable)
             discardable_vars.discard(var.name)
 
-    obj_array_vectorize(remove_result_variable, result)
+    obj_array.vectorize(remove_result_variable, result)
 
     # }}}
 

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -492,8 +492,8 @@ class MatVecOp:
             components.append(component)
 
         if self._operator_uses_obj_array:
-            from pytools.obj_array import make_obj_array
-            return make_obj_array(components)
+            from pytools import obj_array
+            return obj_array.new_1d(components)
         else:
             return components[0]
 
@@ -651,8 +651,8 @@ def execute(code: Code, exec_mapper, pre_assign_check=None) -> np.ndarray:
             assert target in assignees
             context[target] = value
 
-    from pytools.obj_array import obj_array_vectorize
-    return obj_array_vectorize(exec_mapper, code.result)
+    from pytools import obj_array
+    return obj_array.vectorize(exec_mapper, code.result)
 
 # }}}
 
@@ -967,8 +967,8 @@ def build_matrix(actx, places, exprs, input_exprs, domains=None,
     exprs = _prepare_expr(places, exprs, auto_where=auto_where)
 
     if not (isinstance(exprs, np.ndarray) and exprs.dtype.char == "O"):
-        from pytools.obj_array import make_obj_array
-        exprs = make_obj_array([exprs])
+        from pytools import obj_array
+        exprs = obj_array.new_1d([exprs])
 
     try:
         input_exprs = list(input_exprs)

--- a/pytential/symbolic/matrix.py
+++ b/pytential/symbolic/matrix.py
@@ -401,8 +401,8 @@ class MatrixBuilder(MatrixBuilderBase):
                     expr.from_dd.geometry, expr.from_dd.discr_stage)
             template_ary = actx.thaw(discr.nodes()[0])
 
-            from pytools.obj_array import make_obj_array
-            return make_obj_array([
+            from pytools import obj_array
+            return obj_array.new_1d([
                 actx.to_numpy(flatten(
                     conn(unflatten(template_ary, actx.from_numpy(o), actx)),
                     actx))

--- a/pytential/symbolic/old_diffop_primitives.py
+++ b/pytential/symbolic/old_diffop_primitives.py
@@ -1,30 +1,26 @@
 # {{{ differential operators on layer potentials
 
 def grad_S(kernel, arg, dim):
-    from pytools.obj_array import log_shape
-    arg_shape = log_shape(arg)
-    result = np.zeros(arg_shape+(dim,), dtype=object)
+    result = np.zeros(arg.shape+(dim,), dtype=object)
     from pytools import indices_in_shape
-    for i in indices_in_shape(arg_shape):
+    for i in indices_in_shape(arg.shape):
         for j in range(dim):
             result[i+(j,)] = IntGdTarget(kernel, arg[i], j)
     return result
 
 
 def grad_D(kernel, arg, dim):
-    from pytools.obj_array import log_shape
-    arg_shape = log_shape(arg)
-    result = np.zeros(arg_shape+(dim,), dtype=object)
+    result = np.zeros(arg.shape+(dim,), dtype=object)
     from pytools import indices_in_shape
-    for i in indices_in_shape(arg_shape):
+    for i in indices_in_shape(arg.shape):
         for j in range(dim):
             result[i+(j,)] = IntGdMixed(kernel, arg[i], j)
     return result
 
 
 def tangential_surf_grad_source_S(kernel, arg, dim=3):
-    from pytools.obj_array import make_obj_array
-    return make_obj_array([
+    from pytools import obj_array
+    return obj_array.new_1d([
         IntGdSource(kernel, arg,
             ds_direction=make_tangent(i, dim, "src"))
         for i in range(dim-1)])
@@ -42,7 +38,7 @@ def curl_curl_S_volume(k, arg):
     # By vector identity, this is grad div S volume + k^2 S_k(arg),
     # since S_k(arg) satisfies a Helmholtz equation.
 
-    from pytools.obj_array import make_obj_array
+    from pytools import obj_array
 
     def swap_min_first(i, j):
         if i < j:
@@ -50,7 +46,7 @@ def curl_curl_S_volume(k, arg):
         else:
             return j, i
 
-    return make_obj_array([
+    return obj_array.new_1d([
         sum(IntGd2Target(k, arg[m], *swap_min_first(m, n)) for m in range(3))
         for n in range(3)]) + k**2*S(k, arg)
 
@@ -133,8 +129,8 @@ def project_to_tangential(xyz_vec, which=None):
 
 def surf_n_cross(tangential_vec):
     assert len(tangential_vec) == 2
-    from pytools.obj_array import make_obj_array
-    return make_obj_array([-tangential_vec[1], tangential_vec[0]])
+    from pytools import obj_array
+    return obj_array.new_1d([-tangential_vec[1], tangential_vec[0]])
 
 # }}}
 

--- a/pytential/symbolic/pde/cahn_hilliard.py
+++ b/pytential/symbolic/pde/cahn_hilliard.py
@@ -83,11 +83,13 @@ class CahnHilliardOperator(L2WeightedPDEOperator):
                         qbx_forced_limit="avg",
                         op_map=partial(sym.normal_derivative, 2))
 
-        d = sym.make_obj_array([
+        from pytools import obj_array
+
+        d = obj_array.new_1d([
             0.5*sig1,
             0.5*lam2**2*sig1 - 0.5*sig2
             ])
-        a = sym.make_obj_array([
+        a = obj_array.new_1d([
             # A11
             Sn_G(1, sig1) + c*S_G(1, sig1)
             # A12

--- a/pytential/symbolic/pde/maxwell/generalized_debye.py
+++ b/pytential/symbolic/pde/maxwell/generalized_debye.py
@@ -151,8 +151,8 @@ class DebyeOperatorBase:
         E = 1j*k*A - grad_phi - curl_S_volume(k, m)
         H = curl_S_volume(k, j) + 1j*k*Q - grad_psi
 
-        from pytools.obj_array import flat_obj_array
-        return flat_obj_array(E, H)
+        from pytools import obj_array
+        return obj_array.flat(E, H)
 
     def integral_equation(self, *args, **kwargs):
         nxnxE, ndotH = self.boundary_field(*args)
@@ -162,8 +162,8 @@ class DebyeOperatorBase:
         if kwargs:
             raise TypeError("invalid keyword argument(s)")
 
-        from pytools.obj_array import make_obj_array
-        eh_op = make_obj_array([
+        from pytools import obj_array
+        eh_op = obj_array.new_1d([
             2*_debye_S0_surf_div(nxnxE),
             -ndotH,
             ]) + fix
@@ -176,8 +176,8 @@ class DebyeOperatorBase:
         E_minus_grad_phi = 1j*k*A - curl_S_volume(k, m)
 
         from hellskitchen.fmm import DifferenceKernel
-        from pytools.obj_array import flat_obj_array
-        return flat_obj_array(
+        from pytools import obj_array
+        return obj_array.flat(
                 eh_op,
                 # FIXME: These are inefficient. They compute a full volume field,
                 # but only actually use the line part of it.
@@ -220,8 +220,8 @@ class DebyeOperatorBase:
                     self.h_on_spanning_surface_symbols)]
                 )
 
-        from pytools.obj_array import make_obj_array
-        return make_obj_array(result)
+        from pytools import obj_array
+        return obj_array.new_1d(result)
 
 
     def harmonic_vector_field_current(self, hvf_coefficients):
@@ -260,10 +260,10 @@ class InvertingDebyeOperatorBase(DebyeOperatorBase):
             r_coeff = inv_rank_one_coeff(r_tilde)
             q_coeff = inv_rank_one_coeff(q_tilde)
 
-            from pytools.obj_array import flat_obj_array
+            from pytools import obj_array
             factors = self.cluster_points()
 
-            fix = flat_obj_array(
+            fix = obj_array.flat(
                     factors[0]*s_ones*r_coeff,
                     factors[1]*Ones()*q_coeff,
                     )
@@ -374,10 +374,10 @@ class NonInvertingDebyeOperator(DebyeOperatorBase):
             r_coeff = inv_rank_one_coeff(r_tilde)
             q_coeff = inv_rank_one_coeff(q_tilde)
 
-            from pytools.obj_array import flat_obj_array
+            from pytools import obj_array
             factors = self.cluster_points()
 
-            fix = flat_obj_array(
+            fix = obj_array.flat(
                     factors[0]*s_ones*(r_coeff),
                     factors[1]*Ones()*(q_coeff),
                     )

--- a/pytential/unregularized.py
+++ b/pytential/unregularized.py
@@ -108,11 +108,11 @@ class UnregularizedLayerPotentialSource(LayerPotentialSourceBase):
                    category=UnableToCollectTimingData,
                    stacklevel=2)
 
-        from pytools.obj_array import obj_array_vectorize
+        from pytools import obj_array
 
         def evaluate_wrapper(expr):
             value = evaluate(expr)
-            return obj_array_vectorize(lambda x: x, value)
+            return obj_array.vectorize(lambda x: x, value)
 
         if self.fmm_level_to_order is False:
             func = self.exec_compute_potential_insn_direct

--- a/test/extra_matrix_data.py
+++ b/test/extra_matrix_data.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import numpy as np
 
-from pytools.obj_array import make_obj_array
+from pytools import obj_array
 
 from pytential import sym
 from pytential.symbolic.dof_desc import DiscretizationStages
@@ -115,7 +115,7 @@ class MatrixTestCaseMixin:
 
         elif self.op_type == "vector":
             sym_u = sym.make_sym_vector("u", ambient_dim)
-            sym_op = make_obj_array([
+            sym_op = obj_array.new_1d([
                 sym.Sp(knl, sym_u[0], **double_kwargs)
                 + sym.D(knl, sym_u[1], **double_kwargs),
                 sym.S(knl, 0.4 * sym_u[0], **single_kwargs)
@@ -123,7 +123,7 @@ class MatrixTestCaseMixin:
                 ])
 
             if double_kwargs["qbx_forced_limit"] == "avg":
-                sym_op = 0.5 * self.side * make_obj_array([
+                sym_op = 0.5 * self.side * obj_array.new_1d([
                     -sym_u[0] + sym_u[1],
                     0.3 * sym_u[0]
                     ]) + sym_op

--- a/test/test_cost_model.py
+++ b/test/test_cost_model.py
@@ -492,8 +492,8 @@ class ConstantOneQBXExpansionWrangler(ConstantOneExpansionWrangler):
         return np.zeros(non_qbx_box_target_lists.nfiltered_targets)
 
     def full_output_zeros(self, template_ary):
-        from pytools.obj_array import make_obj_array
-        return make_obj_array([np.zeros(self.tree.ntargets)])
+        from pytools import obj_array
+        return obj_array.new_1d([np.zeros(self.tree.ntargets)])
 
     def qbx_local_expansion_zeros(self):
         return np.zeros(self.geo_data.ncenters)

--- a/test/test_layer_pot.py
+++ b/test/test_layer_pot.py
@@ -501,11 +501,13 @@ def test_3d_jump_relations(actx_factory, relation, visualize=False):
                     - 0.5*sym.tangential_to_xyz(density_sym)
                     )
 
+            from pytools import obj_array
+
             # The tangential coordinate system is element-local, so we can't just
             # conjure up some globally smooth functions, interpret their values
             # in the tangential coordinate system, and be done. Instead, generate
             # an XYZ function and project it.
-            jxyz = sym.make_obj_array([
+            jxyz = obj_array.new_1d([
                 actx.np.cos(0.5*x) * actx.np.cos(0.5*y) * actx.np.cos(0.5*z),
                 actx.np.sin(0.5*x) * actx.np.cos(0.5*y) * actx.np.sin(0.5*z),
                 actx.np.sin(0.5*x) * actx.np.cos(0.5*y) * actx.np.cos(0.5*z),

--- a/test/test_matrix.py
+++ b/test/test_matrix.py
@@ -32,7 +32,7 @@ import numpy.linalg as la
 from arraycontext import flatten, unflatten
 from pytential import bind, sym
 from pytential import GeometryCollection
-from pytools.obj_array import make_obj_array
+from pytools import obj_array
 from meshmode.mesh.generation import ellipse, NArmedStarfish
 
 from meshmode import _acf           # noqa: F401
@@ -163,7 +163,7 @@ def test_build_matrix(actx_factory, k, curve_fn, op_type, visualize=False):
     for i in range(5):
         if isinstance(sym_u, np.ndarray):
             u = rng.normal(size=(len(sym_u), density_discr.ndofs))
-            u_dev = make_obj_array([
+            u_dev = obj_array.new_1d([
                 unflatten(template_ary, actx.from_numpy(ui), actx, strict=False)
                 for ui in u
                 ])

--- a/test/test_maxwell.py
+++ b/test/test_maxwell.py
@@ -245,8 +245,9 @@ def test_pec_mfie_extinction(actx_factory, case,
     import pyopencl.clrandom as clrandom
     rng = clrandom.PhiloxGenerator(actx.context, seed=12)
 
-    from pytools.obj_array import make_obj_array
-    src_j = make_obj_array([
+    from pytools import obj_array
+
+    src_j = obj_array.new_1d([
             rng.normal(actx.queue, (test_source.ndofs), dtype=np.float64)
             for _ in range(3)])
 
@@ -413,12 +414,14 @@ def test_pec_mfie_extinction(actx_factory, case,
 
         # {{{ check PEC BC on total field
 
+        from pytools import obj_array
+
         bc_repr = EHField(mfie.scattered_volume_field(
             jt_sym, rho_sym, qbx_forced_limit=loc_sign))
         pec_bc_e = sym.n_cross(bc_repr.e + inc_xyz_sym.e)
         pec_bc_h = sym.normal(3).as_vector().dot(bc_repr.h + inc_xyz_sym.h)
 
-        eh_bc_values = bind(places, sym.flat_obj_array(pec_bc_e, pec_bc_h))(
+        eh_bc_values = bind(places, obj_array.flat(pec_bc_e, pec_bc_h))(
                     actx, jt=jt, rho=rho, inc_fld=inc_field_scat.field,
                     **knl_kwargs)
 

--- a/test/test_scalar_int_eq.py
+++ b/test/test_scalar_int_eq.py
@@ -32,7 +32,7 @@ from sumpy.kernel import LaplaceKernel, HelmholtzKernel, BiharmonicKernel
 
 from pytential import bind, sym
 from pytential import GeometryCollection
-from pytools.obj_array import flat_obj_array
+from pytools import obj_array
 
 from meshmode import _acf           # noqa: F401
 from arraycontext import pytest_generate_tests_for_array_contexts
@@ -229,7 +229,7 @@ def run_int_eq_test(actx,
                 auto_where=("point_source", case.name))(
                         actx, charges=source_charges_dev, **case.knl_concrete_kwargs)
 
-        bc = flat_obj_array(bc_u, bc_du)
+        bc = obj_array.flat(bc_u, bc_du)
     else:
         raise ValueError(f"unknown bc_type: '{case.bc_type}'")
 

--- a/test/test_stokes.py
+++ b/test/test_stokes.py
@@ -30,7 +30,7 @@ from pytential import GeometryCollection, bind, sym
 from meshmode.discretization import Discretization
 from meshmode.discretization.poly_element import \
         InterpolatoryQuadratureGroupFactory
-from pytools.obj_array import make_obj_array
+from pytools import obj_array
 
 from meshmode import _acf           # noqa: F401
 from arraycontext import pytest_generate_tests_for_array_contexts
@@ -184,13 +184,13 @@ def run_exterior_stokes(actx_factory, *,
     normal = bind(places, sym.normal(ambient_dim).as_vector())(actx)
 
     rng = np.random.default_rng(seed=42)
-    charges = make_obj_array([
+    charges = obj_array.new_1d([
         actx.from_numpy(rng.normal(size=point_source.ndofs))
         for _ in range(ambient_dim)
         ])
 
     if ambient_dim == 2:
-        total_charge = make_obj_array([
+        total_charge = obj_array.new_1d([
             actx.to_numpy(actx.np.sum(c)) for c in charges
             ])
         omega = bind(places, total_charge * sym.Ones())(actx)
@@ -417,7 +417,7 @@ class StokesletIdentity:
                 mu_sym=1, qbx_forced_limit=+1)
 
     def ref_result(self):
-        return make_obj_array([1.0e-15 * sym.Ones()] * self.ambient_dim)
+        return obj_array.new_1d([1.0e-15 * sym.Ones()] * self.ambient_dim)
 
 
 @pytest.mark.parametrize("cls", [

--- a/test/test_symbolic.py
+++ b/test/test_symbolic.py
@@ -86,9 +86,10 @@ def get_torus_with_ref_mean_curvature(actx, h):
     a = r_major
     b = r_minor
 
+    from pytools import obj_array
+
     u = actx.np.arctan2(nodes[1], nodes[0])
-    from pytools.obj_array import flat_obj_array
-    rvec = flat_obj_array(actx.np.cos(u), actx.np.sin(u), 0*u)
+    rvec = obj_array.flat(actx.np.cos(u), actx.np.sin(u), 0*u)
     rvec = sum(nodes * rvec) - a
     cosv = actx.np.cos(actx.np.arctan2(nodes[2], rvec))
 
@@ -148,8 +149,10 @@ def test_tangential_onb(actx_factory):
     tob = sym.tangential_onb(mesh.ambient_dim)
     nvecs = tob.shape[1]
 
+    from pytools import obj_array
+
     # make sure tangential_onb is mutually orthogonal and normalized
-    orth_check = bind(discr, sym.make_obj_array([
+    orth_check = bind(discr, obj_array.new_1d([
         np.dot(tob[:, i], tob[:, j]) - (1 if i == j else 0)
         for i in range(nvecs) for j in range(nvecs)])
         )(actx)
@@ -160,7 +163,7 @@ def test_tangential_onb(actx_factory):
                 )
 
     # make sure tangential_onb is orthogonal to normal
-    orth_check = bind(discr, sym.make_obj_array([
+    orth_check = bind(discr, obj_array.new_1d([
         np.dot(tob[:, i], sym.normal(mesh.ambient_dim).as_vector())
         for i in range(nvecs)])
         )(actx)
@@ -383,8 +386,9 @@ def principal_curvatures(ambient_dim, dim=None, dofdesc=None):
     from pytential.symbolic.primitives import _small_mat_eigenvalues
     kappa1, kappa2 = _small_mat_eigenvalues(s_op)
 
-    from pytools.obj_array import make_obj_array
-    return make_obj_array([
+    from pytools import obj_array
+
+    return obj_array.new_1d([
         sym.cse(kappa1, "principal_curvature_0", sym.cse_scope.DISCRETIZATION),
         sym.cse(kappa2, "principal_curvature_1", sym.cse_scope.DISCRETIZATION),
         ])
@@ -397,12 +401,13 @@ def principal_directions(ambient_dim, dim=None, dofdesc=None):
     (s11, s12), (_, s22) = s_op
     k1, k2 = principal_curvatures(ambient_dim, dim=dim, dofdesc=dofdesc)
 
-    from pytools.obj_array import make_obj_array
-    d1 = sym.cse(make_obj_array([s12, -(s11 - k1)]), scope=sym.cse_scope.EVALUATION)
-    d2 = sym.cse(make_obj_array([-(s22 - k2), s12]), scope=sym.cse_scope.EVALUATION)
+    from pytools import obj_array
+
+    d1 = sym.cse(obj_array.new_1d([s12, -(s11 - k1)]), scope=sym.cse_scope.EVALUATION)
+    d2 = sym.cse(obj_array.new_1d([-(s22 - k2), s12]), scope=sym.cse_scope.EVALUATION)
 
     form1 = sym.first_fundamental_form(ambient_dim, dim=dim, dofdesc=dofdesc)
-    return make_obj_array([
+    return obj_array.new_1d([
         sym.cse(
             d1 / sym.sqrt(d1 @ (form1 @ d1)),
             "principal_direction_0", sym.cse_scope.DISCRETIZATION),


### PR DESCRIPTION
From a quick grep, the only place where the old functions are used is in a re-export from `pytential.symbolic.primitives`.