### PR TITLE
Build docs in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,6 +87,7 @@ Documentation:
     . ci-support-v0
     build_py_project
     build_docs
+    maybe_upload_docs
   tags:
   - python3
 


### PR DESCRIPTION
Was missing the `maybe_upload_docs` like boxtree.