### PR TITLE
Switches useful-types for optype

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
                 curl -L -O https://tiker.net/ci-support-v0
                 . ./ci-support-v0
                 build_py_project_in_conda_env
-                cipip install pytest pyfmmlib scipy scipy-stubs matplotlib
+                cipip install pytest pyfmmlib scipy scipy-stubs matplotlib optype
                 cipip install basedpyright
                 basedpyright
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ dependencies = [
     "pytools>=2024.1",
     "scipy>=1.2",
     "sumpy>=2022.1",
-    "useful-types",
 ]
 
 [project.optional-dependencies]
@@ -52,7 +51,8 @@ fmmlib = [
     "pyfmmlib>=2023.1",
 ]
 test = [
-    "pylint",
+    "basedpyright",
+    "optype",
     "pytest",
     "ruff",
 ]

--- a/pytential/linalg/gmres.py
+++ b/pytential/linalg/gmres.py
@@ -168,7 +168,7 @@ def _gmres(A, b, restart=None, tol=None, x0=None, dot=None,
         if recalc_r:
             r = b - a_call(x)
 
-        norm_r = norm(r)  # pylint: disable=possibly-used-before-assignment
+        norm_r = norm(r)
         residual_norms.append(norm_r)
 
         if callback is not None:

--- a/pytential/qbx/__init__.py
+++ b/pytential/qbx/__init__.py
@@ -264,7 +264,6 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
             else:
                 assert isinstance(fmm_order, int) and not isinstance(fmm_order, bool)
 
-                # pylint: disable-next=function-redefined
                 def fmm_level_to_order(kernel, kernel_args, tree, level):
                     return fmm_order
         assert isinstance(fmm_level_to_order, bool) or callable(fmm_level_to_order)
@@ -968,7 +967,7 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
             flat_target_nodes = _flat_nodes(target_name)
 
             # FIXME: (Somewhat wastefully) compute P2P for all targets
-            _, output_for_each_kernel = p2p(  # pylint: disable=possibly-used-before-assignment
+            _, output_for_each_kernel = p2p(
                   queue,
                   targets=flat_target_nodes,
                   sources=flat_source_nodes,
@@ -1011,7 +1010,7 @@ class QBXLayerPotentialSource(LayerPotentialSourceBase):
                 tgt_subset_kwargs[f"result_{i}"] = res_i
 
             if qbx_tgt_count:
-                lpot_applier_on_tgt_subset(  # pylint: disable=possibly-used-before-assignment
+                lpot_applier_on_tgt_subset(
                         queue,
                         targets=flat_target_nodes,
                         sources=flat_source_nodes,

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -1572,7 +1572,6 @@ class SingleScalarOperandExpressionWithWhere(ExpressionNode):
     operand: ArithmeticExpression
     """An expression or an array on which to apply the operation."""
 
-    # pylint: disable-next=invalid-field-call
     dofdesc: DOFDescriptor = field(default_factory=lambda: DEFAULT_DOFDESC)
     """The descriptor for the geometry where the *operand* is defined."""
 
@@ -1654,7 +1653,6 @@ class Ones(ExpressionNode):
     """A DOF-vector that is constant *one* on the whole discretization.
     """
 
-    # pylint: disable-next=invalid-field-call
     dofdesc: DOFDescriptor = field(default_factory=lambda: DEFAULT_DOFDESC)
     """A descriptor for the discretization where the array is defined."""
 
@@ -1710,11 +1708,9 @@ class IterativeInverse(ExpressionNode):
     variable_name: str
     """The name of the variable to solve for."""
 
-    # pylint: disable-next=invalid-field-call
     extra_vars: dict[str, Expression] = field(default_factory=dict)
     """A dictionary of additional variables required to define the operator."""
 
-    # pylint: disable-next=invalid-field-call
     dofdesc: DOFDescriptor = field(default_factory=lambda: DEFAULT_DOFDESC)
     """A descriptor for the geometry on which the solution is defined."""
 
@@ -1996,7 +1992,7 @@ class IntG(ExpressionNode):
             for karg in (*kernel.get_args(), *kernel.get_source_args()):
                 kernel_arg_names.add(karg.loopy_arg.name)
 
-        provided_arg_names = set(self.kernel_arguments.keys())  # pylint: disable=no-member
+        provided_arg_names = set(self.kernel_arguments.keys())
         missing_args = kernel_arg_names - provided_arg_names
         if missing_args:
             raise ValueError(

--- a/pytential/unregularized.py
+++ b/pytential/unregularized.py
@@ -91,7 +91,6 @@ class UnregularizedLayerPotentialSource(LayerPotentialSourceBase):
 
         if fmm_level_to_order is None:
             if fmm_order is not False:
-                # pylint: disable-next=function-redefined
                 def fmm_level_to_order(kernel, kernel_args, tree, level):
                     return fmm_order
             else:

--- a/pytential/utils.py
+++ b/pytential/utils.py
@@ -27,20 +27,23 @@ THE SOFTWARE.
 """
 
 import sys
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Protocol
 
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
 
-    from useful_types import SupportsRichComparison
+    from optype import CanGt, CanLt
 
     from pytools import T
+
+    class CanComparison(CanGt[Any], CanLt[Any], Protocol):
+        pass
 
 
 def sort_arrays_together(
             *arys: Sequence[T],
-            key: Callable[[tuple[T, ...]], SupportsRichComparison] | None = None
+            key: Callable[[tuple[T, ...]], CanComparison] | None = None
         ):
     """Sort a sequence of arrays by considering them
     as an array of sequences using the given sorting key

--- a/test/test_layer_pot.py
+++ b/test/test_layer_pot.py
@@ -614,7 +614,7 @@ def test_3d_jump_relations(actx_factory, relation, visualize=False):
 
         # }}}
 
-    logger.info("\n%s", str(eoc_rec))
+    logger.info("\n%s", eoc_rec)
     assert eoc_rec.order_estimate() >= qbx_order - 1.5
 
 # }}}

--- a/test/test_scalar_int_eq.py
+++ b/test/test_scalar_int_eq.py
@@ -481,7 +481,7 @@ def test_integral_equation(actx_factory, case, visualize=False):
     actx = actx_factory()
 
     from pytools.convergence import EOCRecorder
-    logger.info("\n%s", str(case))
+    logger.info("\n%s", case)
 
     eoc_rec_target = EOCRecorder()
     eoc_rec_td = EOCRecorder()

--- a/test/test_stokes.py
+++ b/test/test_stokes.py
@@ -434,7 +434,7 @@ def test_stokeslet_identity(actx_factory, cls, visualize=False):
     case = cls(fmm_backend=None,
             target_order=5, qbx_order=3, source_ovsmp=source_ovsmp)
     identity = StokesletIdentity(case.ambient_dim)
-    logger.info("\n%s", str(case))
+    logger.info("\n%s", case)
 
     from pytools.convergence import EOCRecorder
     eocs = [EOCRecorder() for _ in range(case.ambient_dim)]
@@ -493,7 +493,7 @@ def test_stresslet_identity(actx_factory, cls, visualize=False):
     case = cls(fmm_backend=None,
             target_order=5, qbx_order=3, source_ovsmp=source_ovsmp)
     identity = StressletIdentity(case.ambient_dim)
-    logger.info("\n%s", str(case))
+    logger.info("\n%s", case)
 
     from pytools.convergence import EOCRecorder
     eocs = [EOCRecorder() for _ in range(case.ambient_dim)]


### PR DESCRIPTION
Since `pytools` depends on `optype` now, it seemed like a good idea to use it here too.