### PR TITLE
Use OneKernel directly

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -781,7 +781,7 @@
                 "code": "reportUnusedImport",
                 "range": {
                     "startColumn": 57,
-                    "endColumn": 70,
+                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
@@ -855,7 +855,7 @@
                 "code": "reportUnusedImport",
                 "range": {
                     "startColumn": 57,
-                    "endColumn": 70,
+                    "endColumn": 66,
                     "lineCount": 1
                 }
             },
@@ -29146,6 +29146,14 @@
                 }
             },
             {
+                "code": "reportAbstractUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 18,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 19,
@@ -29271,6 +29279,14 @@
                     "startColumn": 33,
                     "endColumn": 40,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAbstractUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 18,
+                    "lineCount": 4
                 }
             },
             {
@@ -44514,38 +44530,6 @@
                 "range": {
                     "startColumn": 12,
                     "endColumn": 24,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownVariableType",
-                "range": {
-                    "startColumn": 12,
-                    "endColumn": 18,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportOptionalSubscript",
-                "range": {
-                    "startColumn": 21,
-                    "endColumn": 48,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownMemberType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 70,
-                    "lineCount": 1
-                }
-            },
-            {
-                "code": "reportUnknownArgumentType",
-                "range": {
-                    "startColumn": 49,
-                    "endColumn": 55,
                     "lineCount": 1
                 }
             },

--- a/examples/layerpot-3d.py
+++ b/examples/layerpot-3d.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from sumpy.kernel import HelmholtzKernel, LaplaceKernel, one_kernel_2d  # noqa
+from sumpy.kernel import HelmholtzKernel, LaplaceKernel, OneKernel  # noqa
 from sumpy.visualization import FieldPlotter
 
 from pytential import bind, sym

--- a/examples/layerpot.py
+++ b/examples/layerpot.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from meshmode.mesh.generation import drop, ellipse, starfish  # noqa: F401
-from sumpy.kernel import HelmholtzKernel, LaplaceKernel, one_kernel_2d  # noqa: F401
+from sumpy.kernel import HelmholtzKernel, LaplaceKernel, OneKernel  # noqa: F401
 from sumpy.visualization import FieldPlotter
 
 from pytential import bind, sym

--- a/experiments/maxwell.py
+++ b/experiments/maxwell.py
@@ -5,7 +5,7 @@ import numpy as np
 import pyopencl as cl
 from sumpy.visualization import FieldPlotter
 #from mayavi import mlab
-from sumpy.kernel import one_kernel_2d, LaplaceKernel, HelmholtzKernel  # noqa
+from sumpy.kernel import OneKernel, LaplaceKernel, HelmholtzKernel  # noqa
 
 import faulthandler
 faulthandler.enable()

--- a/experiments/maxwell_sphere.py
+++ b/experiments/maxwell_sphere.py
@@ -2,7 +2,7 @@ import numpy as np
 import pyopencl as cl
 from sumpy.visualization import FieldPlotter
 #from mayavi import mlab
-from sumpy.kernel import one_kernel_2d, LaplaceKernel, HelmholtzKernel  # noqa
+from sumpy.kernel import OneKernel, LaplaceKernel, HelmholtzKernel  # noqa
 
 import faulthandler
 faulthandler.enable()

--- a/test/test_layer_pot.py
+++ b/test/test_layer_pot.py
@@ -364,9 +364,9 @@ def test_unregularized_with_ones_kernel(actx_factory: ArrayContextFactory):
         auto_where=("source", "target"),
     )
 
-    from sumpy.kernel import one_kernel_2d
+    from sumpy.kernel import OneKernel
     sigma_sym = sym.var("sigma")
-    op = sym.int_g_vec(one_kernel_2d, sigma_sym, qbx_forced_limit=None)
+    op = sym.int_g_vec(OneKernel(discr.ambient_dim), sigma_sym, qbx_forced_limit=None)
 
     sigma = discr.zeros(actx) + 1
 


### PR DESCRIPTION
This replaced `one_kernel_2d` and `one_kernel_3d` (not actually used) with direct calls to `OneKernel`. These seem to be the only places where those `one_kernel_Nd` things are used (including `sumpy`).