### PR TITLE
Early interp (density)

### DIFF
--- a/examples/helmholtz-dirichlet.py
+++ b/examples/helmholtz-dirichlet.py
@@ -99,7 +99,7 @@ def main(mesh_name="ellipse", visualize=False):
 
     sigma_sym = sym.var("sigma")
     sqrt_w = sym.sqrt_jac_q_weight(2)
-    inv_sqrt_w_sigma = sym.cse(sigma_sym/sqrt_w)
+    inv_sqrt_w_sigma = sym.cse(sym.bremer_weighted_density(sigma_sym/sqrt_w))
 
     # Brakhage-Werner parameter
     alpha = 1j

--- a/examples/scaling-study.py
+++ b/examples/scaling-study.py
@@ -101,7 +101,7 @@ def timing_run(nx, ny, visualize=False):
 
     sigma_sym = sym.var("sigma")
     sqrt_w = sym.sqrt_jac_q_weight(2)
-    inv_sqrt_w_sigma = sym.cse(sigma_sym/sqrt_w)
+    inv_sqrt_w_sigma = sym.cse(sym.bremer_weighted_density(sigma_sym/sqrt_w))
 
     # Brakhage-Werner parameter
     alpha = 1j

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -305,6 +305,9 @@ class EvaluationMapperBase(PymbolicEvaluationMapper[ArrayOrContainerOrScalar]):
         else:
             raise TypeError(f"cannot interpolate '{type(operand).__name__}'")
 
+    def map_bremer_weighted_density(self, expr: pp.BremerWeightedDensity):
+        return self.rec(expr.operand)
+
     def map_interleave(self, expr: pp.Interleave):
         return interleave_dof_arrays(
                         self.places.get_discretization(

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -366,10 +366,15 @@ class EvaluationRewriter(EvaluationRewriterBase):
         if child is expr.child:
             return expr
 
+        if isinstance(expr, (pp.InterpolationUnit, pp.DistributeInterpolation)):
+            return type(expr)(
+                    child,
+                    expr.prefix,
+                    expr.scope,
+                    **expr.get_extra_properties())
+
         return pp.cse(
-                child,
-                expr.prefix,
-                expr.scope)
+                child, expr.prefix, expr.scope)
 
 # }}}
 
@@ -758,10 +763,24 @@ class EarlyInterpolationAdder(
     """
     from_dd: DOFDescriptor
     to_dd: DOFDescriptor
+    variable_from_dd: DOFDescriptor | None = None
 
     @override
     def map_variable(self, expr: p.Variable):
-        return pp.interpolate(expr, self.from_dd, self.to_dd)
+        from_dd = self.from_dd
+        if self.variable_from_dd is not None:
+            from_dd = self.variable_from_dd
+        return pp.interpolate(expr, from_dd, self.to_dd)
+
+    @override
+    def map_subscript(self, expr: p.Subscript):
+        if isinstance(expr.aggregate, p.Variable):
+            from_dd = self.from_dd
+            if self.variable_from_dd is not None:
+                from_dd = self.variable_from_dd
+            return pp.interpolate(expr, from_dd, self.to_dd)
+
+        return super().map_subscript(expr)
 
     def map_q_weight(self, expr: pp.QWeight):
         raise ValueError(
@@ -798,6 +817,277 @@ class EarlyInterpolationAdder(
                 **expr.get_extra_properties())
 
 
+class _QWeightCollector(Collector[pp.QWeight]):
+    @override
+    def map_q_weight(self, expr: pp.QWeight):
+        return {expr}
+
+
+class _VariableCollector(Collector[p.Variable]):
+    @override
+    def map_variable(self, expr: p.Variable):
+        return {expr}
+
+    @override
+    def map_call(self, expr: p.Call):
+        result: set[p.Variable] = set()
+        for child in expr.parameters:
+            result |= self.rec(child)
+        return result
+
+    @override
+    def map_call_with_kwargs(self, expr: p.CallWithKwargs):
+        result: set[p.Variable] = set()
+        for child in expr.parameters:
+            result |= self.rec(child)
+        for child in expr.kw_parameters.values():
+            result |= self.rec(child)
+        return result
+
+
+class _DensityInterpolationUnitCollector(Collector[p.CommonSubexpression]):
+    @override
+    def map_common_subexpression(self, expr: p.CommonSubexpression):
+        if isinstance(expr, pp.InterpolationUnit):
+            return {expr}
+
+        return self.rec(expr.child)
+
+
+class _DistributedInterpolationCollector(Collector[pp.DistributeInterpolation]):
+    @override
+    def map_common_subexpression(self, expr: p.CommonSubexpression):
+        if isinstance(expr, pp.DistributeInterpolation):
+            return {expr}
+
+        return self.rec(expr.child)
+
+
+class _DensityInterpolationSplitter:
+    def __init__(self,
+            preprocessor: InterpolationPreprocessor,
+            geometry_from_dd: DOFDescriptor,
+            variable_from_dd: DOFDescriptor,
+            to_dd: DOFDescriptor,
+            ) -> None:
+        self.preprocessor = preprocessor
+        self.variable_from_dd = variable_from_dd
+        self.to_dd = to_dd
+        self.geometry_adder = EarlyInterpolationAdder(
+                geometry_from_dd, to_dd, variable_from_dd=variable_from_dd)
+        self.qweight_collector = _QWeightCollector()
+        self.variable_collector = _VariableCollector()
+        self.interpolation_unit_collector = _DensityInterpolationUnitCollector()
+
+    # Marked densities may contain both geometry quantities and density
+    # unknowns. For example, normal*u/sqrt_jac_q_weight should become
+    # normal formed from geometry_from_dd and interpolated to to_dd, multiplied
+    # by Interp(u/sqrt_jac_q_weight) from variable_from_dd to to_dd. The
+    # QWeight-scaled unknown is kept atomic.
+
+    def __call__(self, expr: ArithmeticExpression) -> ArithmeticExpression:
+        return self.rec_arith(expr)
+
+    def _contains_qweight(self, expr: ArithmeticExpression) -> bool:
+        return bool(self.qweight_collector(expr))
+
+    def _contains_variable(self, expr: ArithmeticExpression) -> bool:
+        return bool(self.variable_collector(expr))
+
+    def _contains_interpolation_unit(self, expr: ArithmeticExpression) -> bool:
+        return bool(self.interpolation_unit_collector(expr))
+
+    def _is_interpolation_unit(self, expr: Expression) -> bool:
+        return isinstance(expr, pp.InterpolationUnit)
+
+    def _is_distributed_interpolation(self, expr: Expression) -> bool:
+        return isinstance(expr, pp.DistributeInterpolation)
+
+    def _is_pure_geometry(self, expr: ArithmeticExpression) -> bool:
+        return not (
+                self._contains_qweight(expr)
+                or self._contains_variable(expr)
+                or self._contains_interpolation_unit(expr))
+
+    def _is_variable_leaf(self, expr: ArithmeticExpression) -> bool:
+        return (
+                isinstance(expr, p.Variable)
+                or (
+                    isinstance(expr, p.Subscript)
+                    and isinstance(expr.aggregate, p.Variable)))
+
+    def _factorize(self, expr: ArithmeticExpression) -> ArithmeticExpression:
+        return self.geometry_adder.rec_arith(
+                self.preprocessor.rec_arith(
+                    self.preprocessor.tagger.rec_arith(expr)))
+
+    def _interpolate_as_unit(self,
+            expr: ArithmeticExpression,
+            ) -> ArithmeticExpression:
+        return pp.interpolate(
+                self.preprocessor.rec_arith(expr),
+                self.variable_from_dd,
+                self.to_dd)
+
+    def _distribute_interpolation(
+            self,
+            expr: pp.DistributeInterpolation,
+            ) -> ArithmeticExpression:
+        return self.rec_arith(expr.child)
+
+    def _flatten_product(self,
+            expr: ArithmeticExpression,
+            ) -> list[ArithmeticExpression]:
+        if isinstance(expr, p.Product):
+            result = []
+            for child in expr.children:
+                result.extend(self._flatten_product(child))
+            return result
+
+        return [expr]
+
+    def _flatten_distributed_product(self,
+            expr: ArithmeticExpression,
+            ) -> list[ArithmeticExpression]:
+        result = []
+        for factor in self._flatten_product(expr):
+            if self._is_distributed_interpolation(factor):
+                result.extend(self._flatten_distributed_product(factor.child))
+            else:
+                result.append(factor)
+
+        return result
+
+    def _make_product(self,
+            factors: Iterable[ArithmeticExpression],
+            ) -> ArithmeticExpression:
+        factors = tuple(factors)
+        if not factors:
+            return 1
+        if len(factors) == 1:
+            return factors[0]
+
+        return p.Product(factors)
+
+    def _partition_factors(self,
+            factors: Iterable[ArithmeticExpression],
+            ) -> tuple[list[ArithmeticExpression], list[ArithmeticExpression]]:
+        geometry_factors = []
+        residual_factors = []
+
+        for factor in factors:
+            if self._is_pure_geometry(factor):
+                geometry_factors.append(self._factorize(factor))
+            else:
+                residual_factors.append(factor)
+
+        return geometry_factors, residual_factors
+
+    def rec_arith(self, expr: ArithmeticExpression) -> ArithmeticExpression:
+        if self._is_interpolation_unit(expr):
+            return self._interpolate_as_unit(expr)
+        if self._is_distributed_interpolation(expr):
+            return self._distribute_interpolation(expr)
+
+        if isinstance(expr, p.CommonSubexpression):
+            result = self.rec_arith(expr.child)
+            if result is expr.child:
+                return expr
+
+            return type(expr)(
+                    result,
+                    expr.prefix,
+                    expr.scope,
+                    **expr.get_extra_properties())
+
+        if isinstance(expr, p.Sum):
+            return self.map_sum(expr)
+
+        if isinstance(expr, p.Product):
+            return self.map_product(expr)
+
+        if isinstance(expr, p.Quotient):
+            return self.map_quotient(expr)
+
+        if self._contains_qweight(expr) or self._contains_interpolation_unit(expr):
+            return self._interpolate_as_unit(expr)
+
+        if self._contains_variable(expr) and not self._is_variable_leaf(expr):
+            return self._interpolate_as_unit(expr)
+
+        return self._factorize(expr)
+
+    def map_product(self, expr: p.Product) -> ArithmeticExpression:
+        factors = self._flatten_distributed_product(expr)
+        geometry_factors, residual_factors = self._partition_factors(factors)
+
+        if self._contains_qweight(expr):
+            result_factors = list(geometry_factors)
+            if residual_factors:
+                result_factors.append(
+                        self._interpolate_as_unit(
+                            self._make_product(residual_factors)))
+
+            return self._make_product(result_factors)
+
+        result_factors = list(geometry_factors)
+        if len(residual_factors) == 1:
+            result_factors.append(self.rec_arith(residual_factors[0]))
+        elif residual_factors:
+            result_factors.append(
+                    self._interpolate_as_unit(
+                        self._make_product(residual_factors)))
+
+        return self._make_product(result_factors)
+
+    def map_sum(self, expr: p.Sum) -> ArithmeticExpression:
+        children = tuple(self.rec_arith(child) for child in expr.children)
+        if all(
+                child is orig_child
+                for child, orig_child in zip(children, expr.children, strict=True)):
+            return expr
+
+        from pymbolic.primitives import flattened_sum
+        return flattened_sum(children)
+
+    def map_quotient(self, expr: p.Quotient) -> ArithmeticExpression:
+        if self._contains_qweight(expr):
+            if self._contains_qweight(expr.denominator):
+                numerator_factors = self._flatten_distributed_product(expr.numerator)
+                geometry_factors, residual_numerator_factors = (
+                        self._partition_factors(numerator_factors))
+
+                residual = p.Quotient(
+                        self._make_product(residual_numerator_factors),
+                        expr.denominator)
+                return self._make_product([
+                        *geometry_factors,
+                        self._interpolate_as_unit(residual)])
+
+            if self._is_pure_geometry(expr.denominator):
+                return p.Quotient(
+                        self._interpolate_as_unit(expr.numerator),
+                        self._factorize(expr.denominator))
+
+            return self._interpolate_as_unit(expr)
+
+        if self._is_pure_geometry(expr.denominator):
+            return p.Quotient(
+                    self.rec_arith(expr.numerator),
+                    self._factorize(expr.denominator))
+
+        numerator_factors = self._flatten_distributed_product(expr.numerator)
+        geometry_factors, residual_numerator_factors = (
+                self._partition_factors(numerator_factors))
+
+        residual = p.Quotient(
+                self._make_product(residual_numerator_factors),
+                expr.denominator)
+        return self._make_product([
+                *geometry_factors,
+                self._interpolate_as_unit(residual)])
+
+
 class InterpolationPreprocessor(IdentityMapper):
     """Handle expressions that require upsampling or downsampling by inserting
     a :class:`~pytential.symbolic.primitives.Interpolation`. This is used to
@@ -808,6 +1098,12 @@ class InterpolationPreprocessor(IdentityMapper):
     * upsample layer potential sources to
       :attr:`~pytential.symbolic.dof_desc.QBX_SOURCE_QUAD_STAGE2`, if a
       stage is not already assigned to the source descriptor.
+
+    Unmarked layer-potential densities are interpolated as whole units. Only
+    densities marked with :func:`pytential.symbolic.primitives.geo_density` or
+    :func:`pytential.symbolic.primitives.distribute_interpolation` are split.
+    These markers are only honored in layer-potential densities, not in kernel
+    arguments.
 
     .. attribute:: from_discr_stage
     .. automethod:: __init__
@@ -857,14 +1153,27 @@ class InterpolationPreprocessor(IdentityMapper):
         if not isinstance(lpot_source, QBXLayerPotentialSource):
             return expr
 
-        from_dd = expr.source.to_stage1()
-        to_dd = from_dd.to_quad_stage2()
-        densities = tuple(
-            pp.interpolate(self.rec_arith(density), from_dd, to_dd)
-            for density in expr.densities)
+        variable_from_dd = expr.source.to_stage1()
+        to_dd = variable_from_dd.to_quad_stage2()
 
-        from_dd = from_dd.copy(discr_stage=self.from_discr_stage)
-        interp_adder = EarlyInterpolationAdder(from_dd, to_dd)
+        # stage1 density discretization for geometry can give wrong values for
+        # quantities that depend on the stage2 element parameterization, such as
+        # area_element.
+        geometry_from_dd = variable_from_dd.copy(discr_stage=self.from_discr_stage)
+
+        density_splitter = _DensityInterpolationSplitter(
+                self, geometry_from_dd, variable_from_dd, to_dd)
+        distributed_interpolation_collector = _DistributedInterpolationCollector()
+
+        def process_density(density: ArithmeticExpression) -> ArithmeticExpression:
+            if distributed_interpolation_collector(density):
+                return density_splitter(density)
+            return pp.interpolate(
+                    self.rec_arith(density), variable_from_dd, to_dd)
+
+        densities = tuple(process_density(density) for density in expr.densities)
+
+        interp_adder = EarlyInterpolationAdder(geometry_from_dd, to_dd)
         kernel_arguments = constantdict({
                 name: componentwise(
                     lambda aexpr: interp_adder.rec_arith(

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -383,13 +383,6 @@ class EvaluationRewriter(EvaluationRewriterBase):
         if child is expr.child:
             return expr
 
-        if isinstance(expr, pp.InterpolationUnit):
-            return type(expr)(
-                    child,
-                    expr.prefix,
-                    expr.scope,
-                    **expr.get_extra_properties())
-
         return pp.cse(
                 child, expr.prefix, expr.scope)
 
@@ -831,12 +824,6 @@ class EarlyInterpolationAdder(
     def map_common_subexpression(self,
                 expr: p.CommonSubexpression, /,
             ) -> Expression:
-        if isinstance(expr, pp.InterpolationUnit):
-            from_dd = self.from_dd
-            if self.variable_from_dd is not None:
-                from_dd = self.variable_from_dd
-            return pp.interpolate(expr, from_dd, self.to_dd)
-
         return CSECachingMapperMixin.map_common_subexpression(self, expr)
 
     @override

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -192,6 +192,13 @@ class IdentityMapper(IdentityMapperBase[[]]):
 
         return type(expr)(expr.from_dd, expr.to_dd, operand)
 
+    def map_bremer_weighted_density(self, expr: pp.BremerWeightedDensity):
+        operand = self.rec_arith(expr.operand)
+        if operand is expr.operand:
+            return expr
+
+        return type(expr)(operand)
+
     def map_interleave(self, expr: pp.Interleave):
         operand_1 = self.rec_arith(expr.operand_1)
         operand_2 = self.rec_arith(expr.operand_2)
@@ -227,6 +234,7 @@ class CombineMapper(CombineMapperBase[ResultT, []]):
                 | pp.ElementwiseMin
                 | pp.ElementwiseMax
                 | pp.Interpolation
+                | pp.BremerWeightedDensity
             ):
         return self.rec(expr.operand)
 
@@ -242,6 +250,8 @@ class CombineMapper(CombineMapperBase[ResultT, []]):
     map_elementwise_max: \
         Callable[[Self, pp.ElementwiseMax], ResultT] = _map_with_operand
     map_interpolation: Callable[[Self, pp.Interpolation], ResultT] = _map_with_operand
+    map_bremer_weighted_density: \
+        Callable[[Self, pp.BremerWeightedDensity], ResultT] = _map_with_operand
 
     def map_interleave(self, expr: pp.Interleave):
         return self.combine([self.rec(expr.operand_1), self.rec(expr.operand_2)])
@@ -353,6 +363,13 @@ class EvaluationRewriter(EvaluationRewriterBase):
 
         return type(expr)(expr.ref_axes, operand, expr.dofdesc)
 
+    def map_bremer_weighted_density(self, expr: pp.BremerWeightedDensity):
+        operand = self.rec(expr.operand)
+        if operand is expr.operand:
+            return expr
+
+        return type(expr)(operand)
+
     def map_int_g(self, expr: pp.IntG):
         densities, kernel_arguments, changed = rec_int_g_arguments(self, expr)
         if not changed:
@@ -366,7 +383,7 @@ class EvaluationRewriter(EvaluationRewriterBase):
         if child is expr.child:
             return expr
 
-        if isinstance(expr, (pp.InterpolationUnit, pp.DistributeInterpolation)):
+        if isinstance(expr, pp.InterpolationUnit):
             return type(expr)(
                     child,
                     expr.prefix,
@@ -784,8 +801,16 @@ class EarlyInterpolationAdder(
 
     def map_q_weight(self, expr: pp.QWeight):
         raise ValueError(
-            "EarlyInterpolationAdder must not interpolate a QWeight: "
-            "quadrature weights are intrinsic to their discretization stage")
+            "EarlyInterpolationAdder reached a bare QWeight.")
+
+    def map_bremer_weighted_density(
+                self,
+                expr: pp.BremerWeightedDensity,
+            ) -> Expression:
+        from_dd = self.from_dd
+        if self.variable_from_dd is not None:
+            from_dd = self.variable_from_dd
+        return pp.interpolate(expr, from_dd, self.to_dd)
 
     @override
     def map_call(self,
@@ -803,6 +828,18 @@ class EarlyInterpolationAdder(
         return pp.interpolate(expr, self.from_dd, self.to_dd)
 
     @override
+    def map_common_subexpression(self,
+                expr: p.CommonSubexpression, /,
+            ) -> Expression:
+        if isinstance(expr, pp.InterpolationUnit):
+            from_dd = self.from_dd
+            if self.variable_from_dd is not None:
+                from_dd = self.variable_from_dd
+            return pp.interpolate(expr, from_dd, self.to_dd)
+
+        return CSECachingMapperMixin.map_common_subexpression(self, expr)
+
+    @override
     def map_common_subexpression_uncached(self,
                 expr: p.CommonSubexpression, /,
             ) -> Expression:
@@ -817,277 +854,6 @@ class EarlyInterpolationAdder(
                 **expr.get_extra_properties())
 
 
-class _QWeightCollector(Collector[pp.QWeight]):
-    @override
-    def map_q_weight(self, expr: pp.QWeight):
-        return {expr}
-
-
-class _VariableCollector(Collector[p.Variable]):
-    @override
-    def map_variable(self, expr: p.Variable):
-        return {expr}
-
-    @override
-    def map_call(self, expr: p.Call):
-        result: set[p.Variable] = set()
-        for child in expr.parameters:
-            result |= self.rec(child)
-        return result
-
-    @override
-    def map_call_with_kwargs(self, expr: p.CallWithKwargs):
-        result: set[p.Variable] = set()
-        for child in expr.parameters:
-            result |= self.rec(child)
-        for child in expr.kw_parameters.values():
-            result |= self.rec(child)
-        return result
-
-
-class _DensityInterpolationUnitCollector(Collector[p.CommonSubexpression]):
-    @override
-    def map_common_subexpression(self, expr: p.CommonSubexpression):
-        if isinstance(expr, pp.InterpolationUnit):
-            return {expr}
-
-        return self.rec(expr.child)
-
-
-class _DistributedInterpolationCollector(Collector[pp.DistributeInterpolation]):
-    @override
-    def map_common_subexpression(self, expr: p.CommonSubexpression):
-        if isinstance(expr, pp.DistributeInterpolation):
-            return {expr}
-
-        return self.rec(expr.child)
-
-
-class _DensityInterpolationSplitter:
-    def __init__(self,
-            preprocessor: InterpolationPreprocessor,
-            geometry_from_dd: DOFDescriptor,
-            variable_from_dd: DOFDescriptor,
-            to_dd: DOFDescriptor,
-            ) -> None:
-        self.preprocessor = preprocessor
-        self.variable_from_dd = variable_from_dd
-        self.to_dd = to_dd
-        self.geometry_adder = EarlyInterpolationAdder(
-                geometry_from_dd, to_dd, variable_from_dd=variable_from_dd)
-        self.qweight_collector = _QWeightCollector()
-        self.variable_collector = _VariableCollector()
-        self.interpolation_unit_collector = _DensityInterpolationUnitCollector()
-
-    # Marked densities may contain both geometry quantities and density
-    # unknowns. For example, normal*u/sqrt_jac_q_weight should become
-    # normal formed from geometry_from_dd and interpolated to to_dd, multiplied
-    # by Interp(u/sqrt_jac_q_weight) from variable_from_dd to to_dd. The
-    # QWeight-scaled unknown is kept atomic.
-
-    def __call__(self, expr: ArithmeticExpression) -> ArithmeticExpression:
-        return self.rec_arith(expr)
-
-    def _contains_qweight(self, expr: ArithmeticExpression) -> bool:
-        return bool(self.qweight_collector(expr))
-
-    def _contains_variable(self, expr: ArithmeticExpression) -> bool:
-        return bool(self.variable_collector(expr))
-
-    def _contains_interpolation_unit(self, expr: ArithmeticExpression) -> bool:
-        return bool(self.interpolation_unit_collector(expr))
-
-    def _is_interpolation_unit(self, expr: Expression) -> bool:
-        return isinstance(expr, pp.InterpolationUnit)
-
-    def _is_distributed_interpolation(self, expr: Expression) -> bool:
-        return isinstance(expr, pp.DistributeInterpolation)
-
-    def _is_pure_geometry(self, expr: ArithmeticExpression) -> bool:
-        return not (
-                self._contains_qweight(expr)
-                or self._contains_variable(expr)
-                or self._contains_interpolation_unit(expr))
-
-    def _is_variable_leaf(self, expr: ArithmeticExpression) -> bool:
-        return (
-                isinstance(expr, p.Variable)
-                or (
-                    isinstance(expr, p.Subscript)
-                    and isinstance(expr.aggregate, p.Variable)))
-
-    def _factorize(self, expr: ArithmeticExpression) -> ArithmeticExpression:
-        return self.geometry_adder.rec_arith(
-                self.preprocessor.rec_arith(
-                    self.preprocessor.tagger.rec_arith(expr)))
-
-    def _interpolate_as_unit(self,
-            expr: ArithmeticExpression,
-            ) -> ArithmeticExpression:
-        return pp.interpolate(
-                self.preprocessor.rec_arith(expr),
-                self.variable_from_dd,
-                self.to_dd)
-
-    def _distribute_interpolation(
-            self,
-            expr: pp.DistributeInterpolation,
-            ) -> ArithmeticExpression:
-        return self.rec_arith(expr.child)
-
-    def _flatten_product(self,
-            expr: ArithmeticExpression,
-            ) -> list[ArithmeticExpression]:
-        if isinstance(expr, p.Product):
-            result = []
-            for child in expr.children:
-                result.extend(self._flatten_product(child))
-            return result
-
-        return [expr]
-
-    def _flatten_distributed_product(self,
-            expr: ArithmeticExpression,
-            ) -> list[ArithmeticExpression]:
-        result = []
-        for factor in self._flatten_product(expr):
-            if self._is_distributed_interpolation(factor):
-                result.extend(self._flatten_distributed_product(factor.child))
-            else:
-                result.append(factor)
-
-        return result
-
-    def _make_product(self,
-            factors: Iterable[ArithmeticExpression],
-            ) -> ArithmeticExpression:
-        factors = tuple(factors)
-        if not factors:
-            return 1
-        if len(factors) == 1:
-            return factors[0]
-
-        return p.Product(factors)
-
-    def _partition_factors(self,
-            factors: Iterable[ArithmeticExpression],
-            ) -> tuple[list[ArithmeticExpression], list[ArithmeticExpression]]:
-        geometry_factors = []
-        residual_factors = []
-
-        for factor in factors:
-            if self._is_pure_geometry(factor):
-                geometry_factors.append(self._factorize(factor))
-            else:
-                residual_factors.append(factor)
-
-        return geometry_factors, residual_factors
-
-    def rec_arith(self, expr: ArithmeticExpression) -> ArithmeticExpression:
-        if self._is_interpolation_unit(expr):
-            return self._interpolate_as_unit(expr)
-        if self._is_distributed_interpolation(expr):
-            return self._distribute_interpolation(expr)
-
-        if isinstance(expr, p.CommonSubexpression):
-            result = self.rec_arith(expr.child)
-            if result is expr.child:
-                return expr
-
-            return type(expr)(
-                    result,
-                    expr.prefix,
-                    expr.scope,
-                    **expr.get_extra_properties())
-
-        if isinstance(expr, p.Sum):
-            return self.map_sum(expr)
-
-        if isinstance(expr, p.Product):
-            return self.map_product(expr)
-
-        if isinstance(expr, p.Quotient):
-            return self.map_quotient(expr)
-
-        if self._contains_qweight(expr) or self._contains_interpolation_unit(expr):
-            return self._interpolate_as_unit(expr)
-
-        if self._contains_variable(expr) and not self._is_variable_leaf(expr):
-            return self._interpolate_as_unit(expr)
-
-        return self._factorize(expr)
-
-    def map_product(self, expr: p.Product) -> ArithmeticExpression:
-        factors = self._flatten_distributed_product(expr)
-        geometry_factors, residual_factors = self._partition_factors(factors)
-
-        if self._contains_qweight(expr):
-            result_factors = list(geometry_factors)
-            if residual_factors:
-                result_factors.append(
-                        self._interpolate_as_unit(
-                            self._make_product(residual_factors)))
-
-            return self._make_product(result_factors)
-
-        result_factors = list(geometry_factors)
-        if len(residual_factors) == 1:
-            result_factors.append(self.rec_arith(residual_factors[0]))
-        elif residual_factors:
-            result_factors.append(
-                    self._interpolate_as_unit(
-                        self._make_product(residual_factors)))
-
-        return self._make_product(result_factors)
-
-    def map_sum(self, expr: p.Sum) -> ArithmeticExpression:
-        children = tuple(self.rec_arith(child) for child in expr.children)
-        if all(
-                child is orig_child
-                for child, orig_child in zip(children, expr.children, strict=True)):
-            return expr
-
-        from pymbolic.primitives import flattened_sum
-        return flattened_sum(children)
-
-    def map_quotient(self, expr: p.Quotient) -> ArithmeticExpression:
-        if self._contains_qweight(expr):
-            if self._contains_qweight(expr.denominator):
-                numerator_factors = self._flatten_distributed_product(expr.numerator)
-                geometry_factors, residual_numerator_factors = (
-                        self._partition_factors(numerator_factors))
-
-                residual = p.Quotient(
-                        self._make_product(residual_numerator_factors),
-                        expr.denominator)
-                return self._make_product([
-                        *geometry_factors,
-                        self._interpolate_as_unit(residual)])
-
-            if self._is_pure_geometry(expr.denominator):
-                return p.Quotient(
-                        self._interpolate_as_unit(expr.numerator),
-                        self._factorize(expr.denominator))
-
-            return self._interpolate_as_unit(expr)
-
-        if self._is_pure_geometry(expr.denominator):
-            return p.Quotient(
-                    self.rec_arith(expr.numerator),
-                    self._factorize(expr.denominator))
-
-        numerator_factors = self._flatten_distributed_product(expr.numerator)
-        geometry_factors, residual_numerator_factors = (
-                self._partition_factors(numerator_factors))
-
-        residual = p.Quotient(
-                self._make_product(residual_numerator_factors),
-                expr.denominator)
-        return self._make_product([
-                *geometry_factors,
-                self._interpolate_as_unit(residual)])
-
-
 class InterpolationPreprocessor(IdentityMapper):
     """Handle expressions that require upsampling or downsampling by inserting
     a :class:`~pytential.symbolic.primitives.Interpolation`. This is used to
@@ -1098,12 +864,6 @@ class InterpolationPreprocessor(IdentityMapper):
     * upsample layer potential sources to
       :attr:`~pytential.symbolic.dof_desc.QBX_SOURCE_QUAD_STAGE2`, if a
       stage is not already assigned to the source descriptor.
-
-    Unmarked layer-potential densities are interpolated as whole units. Only
-    densities marked with :func:`pytential.symbolic.primitives.geo_density` or
-    :func:`pytential.symbolic.primitives.distribute_interpolation` are split.
-    These markers are only honored in layer-potential densities, not in kernel
-    arguments.
 
     .. attribute:: from_discr_stage
     .. automethod:: __init__
@@ -1161,17 +921,11 @@ class InterpolationPreprocessor(IdentityMapper):
         # area_element.
         geometry_from_dd = variable_from_dd.copy(discr_stage=self.from_discr_stage)
 
-        density_splitter = _DensityInterpolationSplitter(
-                self, geometry_from_dd, variable_from_dd, to_dd)
-        distributed_interpolation_collector = _DistributedInterpolationCollector()
-
-        def process_density(density: ArithmeticExpression) -> ArithmeticExpression:
-            if distributed_interpolation_collector(density):
-                return density_splitter(density)
-            return pp.interpolate(
-                    self.rec_arith(density), variable_from_dd, to_dd)
-
-        densities = tuple(process_density(density) for density in expr.densities)
+        density_interp_adder = EarlyInterpolationAdder(
+                geometry_from_dd, to_dd, variable_from_dd=variable_from_dd)
+        densities = tuple(
+            density_interp_adder.rec_arith(self.rec_arith(density))
+            for density in expr.densities)
 
         interp_adder = EarlyInterpolationAdder(geometry_from_dd, to_dd)
         kernel_arguments = constantdict({
@@ -1362,6 +1116,14 @@ class StringifyMapper(BaseStringifyMapper[[]]):
                 stringify_where(expr.to_dd),
                 self.rec(expr.operand, PREC_NONE))
 
+    def map_bremer_weighted_density(
+                self,
+                expr: pp.BremerWeightedDensity,
+                enclosing_prec: int,
+            ):
+        return "BremerWeightedDensity({})".format(
+                self.rec(expr.operand, PREC_NONE))
+
     def map_interleave(self, expr: pp.Interleave, enclosing_prec: int):
         return "Interleave[{}]({}, {})".format(
                 stringify_where(expr.from_dd),
@@ -1419,6 +1181,16 @@ class GraphvizMapper(GraphvizMapperBase):
     map_parametrization_derivative = map_pytential_leaf
 
     map_q_weight = map_pytential_leaf
+
+    def map_bremer_weighted_density(self, expr: pp.BremerWeightedDensity):
+        self.lines.append(
+                '{} [label="BremerWeightedDensity",shape=circle];'.format(
+                    self.get_id(expr)))
+        if not self.visit(expr, node_printed=True):
+            return
+
+        self.rec(expr.operand)
+        self.post_visit(expr)
 
     def map_int_g(self, expr: pp.IntG):
         descr = "Int[%s->%s]@(%d) (%s)" % (

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -763,6 +763,11 @@ class EarlyInterpolationAdder(
     def map_variable(self, expr: p.Variable):
         return pp.interpolate(expr, self.from_dd, self.to_dd)
 
+    def map_q_weight(self, expr: pp.QWeight):
+        raise ValueError(
+            "EarlyInterpolationAdder must not interpolate a QWeight: "
+            "quadrature weights are intrinsic to their discretization stage")
+
     @override
     def map_call(self,
                 expr: p.Call,
@@ -854,9 +859,8 @@ class InterpolationPreprocessor(IdentityMapper):
 
         from_dd = expr.source.to_stage1()
         to_dd = from_dd.to_quad_stage2()
-        interp_adder = EarlyInterpolationAdder(from_dd, to_dd)
         densities = tuple(
-            interp_adder.rec_arith(self.rec_arith(density))
+            pp.interpolate(self.rec_arith(density), from_dd, to_dd)
             for density in expr.densities)
 
         from_dd = from_dd.copy(discr_stage=self.from_discr_stage)

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -611,12 +611,13 @@ class DiscretizationStageTagger(IdentityMapper):
     @override
     def map_num_reference_derivative(self, expr: pp.NumReferenceDerivative):
         dofdesc = expr.dofdesc
-        if dofdesc.discr_stage == self.discr_stage:
+        operand = self.rec_arith(expr.operand)
+        if dofdesc.discr_stage == self.discr_stage and operand is expr.operand:
             return expr
 
         return type(expr)(
                 expr.ref_axes,
-                self.rec_arith(expr.operand),
+                operand,
                 dofdesc.copy(discr_stage=self.discr_stage))
 
 # }}}
@@ -805,6 +806,31 @@ class EarlyInterpolationAdder(
             from_dd = self.variable_from_dd
         return pp.interpolate(expr, from_dd, self.to_dd)
 
+    def _map_scalar_reduction(
+                self,
+                expr: pp.NodeSum | pp.NodeMax | pp.NodeMin,
+            ) -> Expression:
+        if self.from_dd.discr_stage is None:
+            return expr
+
+        return DiscretizationStageTagger(self.from_dd.discr_stage).rec_arith(expr)
+
+    def map_node_sum(self, expr: pp.NodeSum) -> Expression:
+        return self._map_scalar_reduction(expr)
+
+    def map_node_max(self, expr: pp.NodeMax) -> Expression:
+        return self._map_scalar_reduction(expr)
+
+    def map_node_min(self, expr: pp.NodeMin) -> Expression:
+        return self._map_scalar_reduction(expr)
+
+    def map_int_g(self, expr: pp.IntG) -> Expression:
+        from_dd = expr.target
+        if from_dd.discr_stage is None:
+            from_dd = from_dd.to_stage1()
+
+        return pp.interpolate(expr, from_dd, self.to_dd)
+
     @override
     def map_call(self,
                 expr: p.Call,
@@ -818,7 +844,13 @@ class EarlyInterpolationAdder(
 
     @override
     def handle_unsupported_expression(self, expr: p.ExpressionNode) -> Expression:
-        return pp.interpolate(expr, self.from_dd, self.to_dd)
+        if self.from_dd.discr_stage is None:
+            operand = expr
+        else:
+            operand = DiscretizationStageTagger(
+                    self.from_dd.discr_stage).rec_arith(expr)
+
+        return pp.interpolate(operand, self.from_dd, self.to_dd)
 
     @override
     def map_common_subexpression(self,
@@ -903,16 +935,14 @@ class InterpolationPreprocessor(IdentityMapper):
         variable_from_dd = expr.source.to_stage1()
         to_dd = variable_from_dd.to_quad_stage2()
 
-        # stage1 density discretization for geometry can give wrong values for
-        # quantities that depend on the stage2 element parameterization, such as
-        # area_element.
-        geometry_from_dd = variable_from_dd.copy(discr_stage=self.from_discr_stage)
+        geometry_from_dd = expr.source.copy(discr_stage=self.from_discr_stage)
 
         density_interp_adder = EarlyInterpolationAdder(
                 geometry_from_dd, to_dd, variable_from_dd=variable_from_dd)
+        rec_densities = tuple(self.rec_arith(density) for density in expr.densities)
         densities = tuple(
-            density_interp_adder.rec_arith(self.rec_arith(density))
-            for density in expr.densities)
+            density_interp_adder.rec_arith(density)
+            for density in rec_densities)
 
         interp_adder = EarlyInterpolationAdder(geometry_from_dd, to_dd)
         kernel_arguments = constantdict({
@@ -998,7 +1028,7 @@ def stringify_where(where: DOFDescriptorLike):
     return str(pp.as_dofdesc(where))
 
 
-class StringifyMapper(BaseStringifyMapper[[]]):
+class StringifyMapper(BaseStringifyMapper):
 
     def map_ones(self, expr: pp.Ones, enclosing_prec: int):
         return "Ones[%s]" % stringify_where(expr.dofdesc)

--- a/pytential/symbolic/pde/scalar.py
+++ b/pytential/symbolic/pde/scalar.py
@@ -88,6 +88,7 @@ class L2WeightedPDEOperator(ABC):
     .. automethod:: get_sqrt_weight
 
     .. automethod:: get_density_var
+    .. automethod:: get_weighted_density
     .. automethod:: prepare_rhs
 
     .. automethod:: representation
@@ -154,6 +155,17 @@ class L2WeightedPDEOperator(ABC):
             corresponding to the density with the given *name*.
         """
         return sym.var(name)
+
+    def get_weighted_density(
+                self,
+                u: ArithmeticExpression,
+                dofdesc: DOFDescriptorLike = None,
+            ) -> ArithmeticExpression:
+        if not self.use_l2_weighting:
+            return sym.cse(u)
+
+        return sym.cse(sym.bremer_weighted_density(
+                u / self.get_sqrt_weight(dofdesc)))
 
     @abstractmethod
     def representation(self,
@@ -284,8 +296,7 @@ class DirichletOperator(L2WeightedPDEOperator):
                        source: DOFDescriptorLike = None,
                        target: DOFDescriptorLike = None,
                        **kwargs: Operand) -> ArithmeticExpression:
-        sqrt_w = self.get_sqrt_weight(source)
-        inv_sqrt_w_u = sym.cse(u/sqrt_w)
+        inv_sqrt_w_u = self.get_weighted_density(u, source)
 
         if map_potentials is None:
             def default_map_potentials(x: ArithmeticExpression) -> ArithmeticExpression:
@@ -319,7 +330,7 @@ class DirichletOperator(L2WeightedPDEOperator):
 
         dofdesc = sym.as_dofdesc(dofdesc)
         sqrt_w = self.get_sqrt_weight(dofdesc)
-        inv_sqrt_w_u = sym.cse(u/sqrt_w)
+        inv_sqrt_w_u = self.get_weighted_density(u, dofdesc)
 
         if self.is_unique_only_up_to_constant():
             # The exterior Dirichlet operator in this representation
@@ -451,8 +462,7 @@ class NeumannOperator(L2WeightedPDEOperator):
         from sumpy.kernel import LaplaceKernel
         laplace = LaplaceKernel(self.dim)
 
-        sqrt_w = self.get_sqrt_weight(source)
-        inv_sqrt_w_u = sym.cse(u/sqrt_w)
+        inv_sqrt_w_u = self.get_weighted_density(u, source)
         laplace_s_inv_sqrt_w_u = sym.cse(
                 sym.S(laplace, inv_sqrt_w_u,
                       qbx_forced_limit=+1,
@@ -485,7 +495,7 @@ class NeumannOperator(L2WeightedPDEOperator):
 
         dofdesc = sym.as_dofdesc(dofdesc)
         sqrt_w = self.get_sqrt_weight(dofdesc)
-        inv_sqrt_w_u = sym.cse(u/sqrt_w)
+        inv_sqrt_w_u = self.get_weighted_density(u, dofdesc)
         laplace_s_inv_sqrt_w_u = sym.cse(
                 sym.S(laplace, inv_sqrt_w_u,
                       qbx_forced_limit=+1,

--- a/pytential/symbolic/pde/scalar.py
+++ b/pytential/symbolic/pde/scalar.py
@@ -38,7 +38,7 @@ __doc__ = """
 """
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, TypeAlias
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import numpy as np
 from typing_extensions import override
@@ -162,10 +162,11 @@ class L2WeightedPDEOperator(ABC):
                 dofdesc: DOFDescriptorLike = None,
             ) -> ArithmeticExpression:
         if not self.use_l2_weighting:
-            return sym.cse(u)
+            return cast("ArithmeticExpression", sym.cse(u))
 
-        return sym.cse(sym.bremer_weighted_density(
-                u / self.get_sqrt_weight(dofdesc)))
+        return cast("ArithmeticExpression", sym.cse(
+                sym.bremer_weighted_density(
+                    u / self.get_sqrt_weight(dofdesc))))
 
     @abstractmethod
     def representation(self,

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -51,10 +51,11 @@ from pymbolic.geometric_algebra.primitives import (
     NablaComponent,
 )
 from pymbolic.primitives import (  # noqa: N813
+    CommonSubexpression,
     Variable as var,
     cse_scope as cse_scope_base,
     expr_dataclass,
-    make_common_subexpression as cse,
+    make_common_subexpression as _cse,
     make_sym_vector,
 )
 from pymbolic.typing import ArithmeticExpression
@@ -92,7 +93,7 @@ if TYPE_CHECKING:
 
     import modepy as mp
     from pymbolic.mapper.stringifier import StringifyMapper
-    from pymbolic.primitives import CommonSubexpression, Quotient
+    from pymbolic.primitives import Quotient
 
 
 __doc__ = """
@@ -231,6 +232,7 @@ Discretization properties
 .. autofunction:: area_element
 .. autofunction:: sqrt_jac_q_weight
 .. autofunction:: normal
+.. autofunction:: geo_density
 .. autofunction:: mean_curvature
 .. autofunction:: first_fundamental_form
 .. autofunction:: second_fundamental_form
@@ -305,6 +307,22 @@ Elementary numerics
 
 Operators
 ^^^^^^^^^
+
+.. autofunction:: cse
+
+.. autoclass:: InterpolationUnit
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
+
+.. autofunction:: interpolation_unit
+
+.. autoclass:: DistributeInterpolation
+    :show-inheritance:
+    :undoc-members:
+    :members: mapper_method
+
+.. autofunction:: distribute_interpolation
 
 .. autoclass:: Interpolation
     :show-inheritance:
@@ -404,7 +422,7 @@ __all__ = (  # noqa: RUF022
 
     "IsShapeClass", "QWeight", "nodes", "parametrization_derivative",
     "parametrization_derivative_matrix", "pseudoscalar", "area_element",
-    "sqrt_jac_q_weight", "normal", "mean_curvature",
+    "sqrt_jac_q_weight", "normal", "geo_density", "mean_curvature",
     "first_fundamental_form", "second_fundamental_form", "shape_operator",
 
     "expansion_radii", "expansion_centers", "h_max", "weights_and_area_elements",
@@ -413,7 +431,8 @@ __all__ = (  # noqa: RUF022
     "ElementwiseMax", "integral", "Ones", "ones_vec", "area", "mean",
     "IterativeInverse",
 
-    "Interpolation", "interpolate",
+    "Interpolation", "interpolate", "InterpolationUnit", "interpolation_unit",
+    "DistributeInterpolation", "distribute_interpolation",
 
     "Derivative",
 
@@ -525,6 +544,87 @@ class ErrorExpression(ExpressionNode):
 
     message: str
     """The error message to raise when this expression is encountered."""
+
+
+@expr_dataclass()
+class InterpolationUnit(CommonSubexpression):
+    """A common subexpression whose value should be interpolated as a unit.
+
+    This is used for quantities whose expanded symbolic form is not a valid
+    place to insert interpolation. For example, the result of
+    :func:`tangential_to_xyz` is Cartesian, while its inputs can be coefficients
+    in an element-local tangential basis.
+    """
+
+    mapper_method = "map_common_subexpression"
+
+
+@for_each_expression
+def interpolation_unit(
+            operand: ArithmeticExpression,
+            prefix: str | None = "interp_unit",
+            scope: str = cse_scope.EVALUATION,
+        ) -> ArithmeticExpression:
+    """Mark *operand* as a quantity that should be interpolated as a whole."""
+
+    return InterpolationUnit(operand, prefix, scope)
+
+
+@expr_dataclass()
+class DistributeInterpolation(CommonSubexpression):
+    """A common subexpression whose source interpolation may be distributed.
+
+    This is an opt-in marker for densities such as ``normal*h`` where the
+    geometry factors should be formed using the geometry-stage element
+    parameterization and the unknown variables are interpolated from the source
+    discretization.
+
+    """
+
+    mapper_method = "map_common_subexpression"
+
+
+@for_each_expression
+def distribute_interpolation(
+            operand: ArithmeticExpression,
+            prefix: str | None = "distribute_interp",
+            scope: str = cse_scope.EVALUATION,
+        ) -> ArithmeticExpression:
+    """Mark *operand* so source-to-quad interpolation may be pushed into it."""
+
+    return DistributeInterpolation(operand, prefix, scope)
+
+
+def cse(
+            expr: Operand,
+            prefix: str | None = None,
+            scope: str | None = None,
+            *,
+            wrap_vars: bool = True,
+        ) -> Operand:
+    """Wrap *expr* in a common subexpression.
+
+    This is the usual :func:`pymbolic.primitives.make_common_subexpression`,
+    except that top-level rewrapping of an :class:`InterpolationUnit` or
+    :class:`DistributeInterpolation` updates its name hint while preserving the
+    marker.
+    """
+
+    if isinstance(expr, (InterpolationUnit, DistributeInterpolation)):
+        if prefix is None:
+            prefix = expr.prefix
+        if scope is None:
+            scope = expr.scope
+        return cast("Operand", type(expr)(
+                expr.child,
+                prefix,
+                scope,
+                **expr.get_extra_properties()))
+
+    if scope is None:
+        scope = cse_scope.EVALUATION
+
+    return cast("Operand", _cse(expr, prefix, scope, wrap_vars=wrap_vars))
 
 
 def make_sym_mv(name: str, num_components: int) -> MultiVector[ArithmeticExpression]:
@@ -892,6 +992,23 @@ def normal(
             pder << pder.I.inv(),
             "normal",
             scope=cse_scope.DISCRETIZATION)
+
+
+def geo_density(
+            geometry: Operand,
+            density: Operand,
+            prefix: str | None = "geo_density",
+        ) -> Operand:
+    """Return ``geometry * density`` with source interpolation distributed.
+
+    This is a helper for densities whose semantic form is a geometric
+    factor multiplying a density unknown. It should not be used for
+    coordinate transforms such as :func:`tangential_to_xyz`, whose inputs are
+    local coordinate components rather than independent scalar densities.
+    """
+
+    return cast("Operand", distribute_interpolation(
+            geometry * density, prefix))
 
 
 def mean_curvature(
@@ -2498,7 +2615,8 @@ def tangential_to_xyz(
     tonb = tangential_onb(ambient_dim, dofdesc=dofdesc)
     result = sum(tonb[:, i] * tangential_vec[i] for i in range(ambient_dim - 1))
 
-    return cast("ObjectArray1D[ArithmeticExpression]", result)
+    return cast("ObjectArray1D[ArithmeticExpression]",
+            interpolation_unit(result, "tangential_to_xyz"))
 
 
 def project_to_tangential(

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -309,13 +309,6 @@ Operators
 
 .. autofunction:: cse
 
-.. autoclass:: InterpolationUnit
-    :show-inheritance:
-    :undoc-members:
-    :members: mapper_method
-
-.. autofunction:: interpolation_unit
-
 .. autoclass:: BremerWeightedDensity
     :show-inheritance:
     :undoc-members:
@@ -430,8 +423,8 @@ __all__ = (  # noqa: RUF022
     "ElementwiseMax", "integral", "Ones", "ones_vec", "area", "mean",
     "IterativeInverse",
 
-    "Interpolation", "interpolate", "InterpolationUnit", "interpolation_unit",
-    "BremerWeightedDensity", "bremer_weighted_density",
+    "Interpolation", "interpolate", "BremerWeightedDensity",
+    "bremer_weighted_density",
 
     "Derivative",
 
@@ -546,30 +539,6 @@ class ErrorExpression(ExpressionNode):
 
 
 @expr_dataclass()
-class InterpolationUnit(CommonSubexpression):
-    """A common subexpression whose value should be interpolated as a unit.
-
-    This is used for quantities whose expanded symbolic form is not a valid
-    place to insert interpolation. For example, the result of
-    :func:`tangential_to_xyz` is Cartesian, while its inputs can be coefficients
-    in an element-local tangential basis.
-    """
-
-    mapper_method = "map_common_subexpression"
-
-
-@for_each_expression
-def interpolation_unit(
-            operand: ArithmeticExpression,
-            prefix: str | None = "interp_unit",
-            scope: str = cse_scope.EVALUATION,
-        ) -> ArithmeticExpression:
-    """Mark *operand* as a quantity that should be interpolated as a whole."""
-
-    return InterpolationUnit(operand, prefix, scope)
-
-
-@expr_dataclass()
 class BremerWeightedDensity(ExpressionNode):
     """A right-preconditioned density with Bremer/L2 quadrature weighting.
 
@@ -595,17 +564,6 @@ def cse(
             *,
             wrap_vars: bool = True,
         ) -> Operand:
-    if isinstance(expr, InterpolationUnit):
-        if prefix is None:
-            prefix = expr.prefix
-        if scope is None:
-            scope = expr.scope
-        return cast("Operand", type(expr)(
-                expr.child,
-                prefix,
-                scope,
-                **expr.get_extra_properties()))
-
     if scope is None:
         scope = cse_scope.EVALUATION
 
@@ -2583,8 +2541,7 @@ def tangential_to_xyz(
     tonb = tangential_onb(ambient_dim, dofdesc=dofdesc)
     result = sum(tonb[:, i] * tangential_vec[i] for i in range(ambient_dim - 1))
 
-    return cast("ObjectArray1D[ArithmeticExpression]",
-            interpolation_unit(result, "tangential_to_xyz"))
+    return cast("ObjectArray1D[ArithmeticExpression]", result)
 
 
 def project_to_tangential(

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -232,7 +232,6 @@ Discretization properties
 .. autofunction:: area_element
 .. autofunction:: sqrt_jac_q_weight
 .. autofunction:: normal
-.. autofunction:: geo_density
 .. autofunction:: mean_curvature
 .. autofunction:: first_fundamental_form
 .. autofunction:: second_fundamental_form
@@ -317,12 +316,12 @@ Operators
 
 .. autofunction:: interpolation_unit
 
-.. autoclass:: DistributeInterpolation
+.. autoclass:: BremerWeightedDensity
     :show-inheritance:
     :undoc-members:
     :members: mapper_method
 
-.. autofunction:: distribute_interpolation
+.. autofunction:: bremer_weighted_density
 
 .. autoclass:: Interpolation
     :show-inheritance:
@@ -422,7 +421,7 @@ __all__ = (  # noqa: RUF022
 
     "IsShapeClass", "QWeight", "nodes", "parametrization_derivative",
     "parametrization_derivative_matrix", "pseudoscalar", "area_element",
-    "sqrt_jac_q_weight", "normal", "geo_density", "mean_curvature",
+    "sqrt_jac_q_weight", "normal", "bremer_weighted_density", "mean_curvature",
     "first_fundamental_form", "second_fundamental_form", "shape_operator",
 
     "expansion_radii", "expansion_centers", "h_max", "weights_and_area_elements",
@@ -432,7 +431,7 @@ __all__ = (  # noqa: RUF022
     "IterativeInverse",
 
     "Interpolation", "interpolate", "InterpolationUnit", "interpolation_unit",
-    "DistributeInterpolation", "distribute_interpolation",
+    "BremerWeightedDensity", "bremer_weighted_density",
 
     "Derivative",
 
@@ -571,28 +570,22 @@ def interpolation_unit(
 
 
 @expr_dataclass()
-class DistributeInterpolation(CommonSubexpression):
-    """A common subexpression whose source interpolation may be distributed.
+class BremerWeightedDensity(ExpressionNode):
+    """A right-preconditioned density with Bremer/L2 quadrature weighting.
 
-    This is an opt-in marker for densities such as ``normal*h`` where the
-    geometry factors should be formed using the geometry-stage element
-    parameterization and the unknown variables are interpolated from the source
-    discretization.
-
+    .. autoattribute:: operand
     """
 
-    mapper_method = "map_common_subexpression"
+    operand: ArithmeticExpression
 
 
 @for_each_expression
-def distribute_interpolation(
+def bremer_weighted_density(
             operand: ArithmeticExpression,
-            prefix: str | None = "distribute_interp",
-            scope: str = cse_scope.EVALUATION,
         ) -> ArithmeticExpression:
-    """Mark *operand* so source-to-quad interpolation may be pushed into it."""
+    """Mark *operand* as a Bremer/L2-weighted density."""
 
-    return DistributeInterpolation(operand, prefix, scope)
+    return BremerWeightedDensity(operand)
 
 
 def cse(
@@ -602,15 +595,7 @@ def cse(
             *,
             wrap_vars: bool = True,
         ) -> Operand:
-    """Wrap *expr* in a common subexpression.
-
-    This is the usual :func:`pymbolic.primitives.make_common_subexpression`,
-    except that top-level rewrapping of an :class:`InterpolationUnit` or
-    :class:`DistributeInterpolation` updates its name hint while preserving the
-    marker.
-    """
-
-    if isinstance(expr, (InterpolationUnit, DistributeInterpolation)):
+    if isinstance(expr, InterpolationUnit):
         if prefix is None:
             prefix = expr.prefix
         if scope is None:
@@ -992,23 +977,6 @@ def normal(
             pder << pder.I.inv(),
             "normal",
             scope=cse_scope.DISCRETIZATION)
-
-
-def geo_density(
-            geometry: Operand,
-            density: Operand,
-            prefix: str | None = "geo_density",
-        ) -> Operand:
-    """Return ``geometry * density`` with source interpolation distributed.
-
-    This is a helper for densities whose semantic form is a geometric
-    factor multiplying a density unknown. It should not be used for
-    coordinate transforms such as :func:`tangential_to_xyz`, whose inputs are
-    local coordinate components rather than independent scalar densities.
-    """
-
-    return cast("Operand", distribute_interpolation(
-            geometry * density, prefix))
 
 
 def mean_curvature(

--- a/pytential/symbolic/primitives.py
+++ b/pytential/symbolic/primitives.py
@@ -414,7 +414,7 @@ __all__ = (  # noqa: RUF022
 
     "IsShapeClass", "QWeight", "nodes", "parametrization_derivative",
     "parametrization_derivative_matrix", "pseudoscalar", "area_element",
-    "sqrt_jac_q_weight", "normal", "bremer_weighted_density", "mean_curvature",
+    "sqrt_jac_q_weight", "normal", "mean_curvature",
     "first_fundamental_form", "second_fundamental_form", "shape_operator",
 
     "expansion_radii", "expansion_centers", "h_max", "weights_and_area_elements",

--- a/test/test_symbolic.py
+++ b/test/test_symbolic.py
@@ -525,8 +525,7 @@ def test_mapper_int_g_term_collector(op_name, k=0):
     expr_only_intgs = IntGTermCollector()(expr)
 
     # FIXME: how to check this did something?
-    sigma = sym.cse(op.get_density_var("sigma") / op.get_sqrt_weight(),
-                    scope=sym.cse_scope.EVALUATION)
+    sigma = op.get_weighted_density(op.get_density_var("sigma"))
     if op_name == "dirichlet":
         expected_expr = -1 * sym.D(op.kernel, sigma, qbx_forced_limit="avg")
     elif op_name == "neumann":


### PR DESCRIPTION
WIP:

This PR adds need-driven interpolation for layer-potential densities.

Plain densities continue to be interpolated as whole units from stage1 to quad_stage2. For densities coupled with geometry factors, this PR adds explicit markers:

 - `sym.distribute_interpolation(expr)` allows interpolation to be pushed into selected density expressions.
 - `sym.geo_density(geometry, density)` is a helper for common `geometry * unknown` densities.
 - `sym.interpolation_unit(expr)` marks quantities that must remain atomic under interpolation.

For example, this lets expressions such as `normal * sigma` be written so that the normal is formed using the stage2 geometry parameterization and interpolated to quad_stage2, while the unknown `sigma` is interpolated from stage1 to quad_stage2. At the same time, QWeight/L2-scaled quantities such as `u / sqrt_jac_q_weight` remain atomic.

`tangential_to_xyz(...)` transforms variables from a local tangential basis to the standard Cartesian basis, so the resulting Cartesian vector should be interpolated as an atomic quantity.