### PR TITLE
Make flatten work on Operands

### DIFF
--- a/.basedpyright/baseline.json
+++ b/.basedpyright/baseline.json
@@ -27914,6 +27914,14 @@
                 }
             },
             {
+                "code": "reportAbstractUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 18,
+                    "lineCount": 4
+                }
+            },
+            {
                 "code": "reportCallIssue",
                 "range": {
                     "startColumn": 19,
@@ -28039,6 +28047,14 @@
                     "startColumn": 33,
                     "endColumn": 40,
                     "lineCount": 1
+                }
+            },
+            {
+                "code": "reportAbstractUsage",
+                "range": {
+                    "startColumn": 19,
+                    "endColumn": 18,
+                    "lineCount": 4
                 }
             },
             {

--- a/pytential/symbolic/execution.py
+++ b/pytential/symbolic/execution.py
@@ -638,7 +638,7 @@ def _prepare_expr(places: GeometryCollection,
 
     # FIXME: There's some mismatch between OperandTc and a conditional union
     # type that I was too impatient to figure out in detail.
-    expr = componentwise(flatten, expr)  # pyright: ignore[reportAssignmentType]
+    expr = flatten(expr)
     auto_source, auto_target = _prepare_auto_where(auto_where, places=places)
     expr = componentwise(  # pyright: ignore[reportAssignmentType]
             ToTargetTagger(

--- a/pytential/symbolic/mappers.py
+++ b/pytential/symbolic/mappers.py
@@ -380,8 +380,17 @@ class FlattenMapper(FlattenMapperBase, IdentityMapper):
     pass
 
 
-def flatten(expr: ArithmeticExpression):
-    return FlattenMapper().rec_arith(expr)
+def flatten(expr: pp.OperandTc) -> pp.OperandTc:
+    from pymbolic.geometric_algebra import MultiVector, componentwise
+    from pytools.obj_array import ObjectArray
+
+    def func(expr_i: ArithmeticExpression) -> ArithmeticExpression:
+        return FlattenMapper().rec_arith(expr_i)
+
+    if isinstance(expr, (ObjectArray, MultiVector)):
+        return componentwise(func, expr)
+    else:
+        return cast("pp.OperandTc", func(expr))
 
 # }}}
 


### PR DESCRIPTION
It seemed like some places where using `componentwise(flatten, expr)`, but this looks nicer + one less import :grin: